### PR TITLE
[ExpiringCache] Fix the get() method on expired entries, some tweaks.

### DIFF
--- a/src/Assetic/Cache/ExpiringCache.php
+++ b/src/Assetic/Cache/ExpiringCache.php
@@ -29,13 +29,12 @@ class ExpiringCache implements CacheInterface
 
     public function has($key)
     {
-        if ($this->cache->has($key)) {
+        if ($this->cache->has($key.'.expires')) {
             if (time() < $this->cache->get($key.'.expires')) {
                 return true;
             }
 
-            $this->cache->remove($key.'.expires');
-            $this->cache->remove($key);
+            $this->remove($key);
         }
 
         return false;
@@ -43,7 +42,7 @@ class ExpiringCache implements CacheInterface
 
     public function get($key)
     {
-        return $this->cache->get($key);
+        return $this->has($key) ? $this->cache->get($key) : null;
     }
 
     public function set($key, $value)

--- a/tests/Assetic/Test/Cache/ExpiringCacheTest.php
+++ b/tests/Assetic/Test/Cache/ExpiringCacheTest.php
@@ -34,7 +34,7 @@ class ExpiringCacheTest extends \PHPUnit_Framework_TestCase
 
         $this->inner->expects($this->once())
             ->method('has')
-            ->with($key)
+            ->with($expiresKey)
             ->will($this->returnValue(true));
         $this->inner->expects($this->once())
             ->method('get')
@@ -58,7 +58,7 @@ class ExpiringCacheTest extends \PHPUnit_Framework_TestCase
 
         $this->inner->expects($this->once())
             ->method('has')
-            ->with($key)
+            ->with($expiresKey)
             ->will($this->returnValue(true));
         $this->inner->expects($this->once())
             ->method('get')
@@ -98,14 +98,50 @@ class ExpiringCacheTest extends \PHPUnit_Framework_TestCase
 
         $this->cache->remove($key);
     }
-
-    public function testGet()
+   
+    public function testGetExpired()
     {
+        $key = 'asdf';
+        $expiresKey = 'asdf.expires';
+        $thePast = 0;
+
+        $this->inner->expects($this->once())
+            ->method('has')
+            ->with($expiresKey)
+            ->will($this->returnValue(true));
         $this->inner->expects($this->once())
             ->method('get')
-            ->with('foo')
-            ->will($this->returnValue('bar'));
+            ->with($expiresKey)
+            ->will($this->returnValue($thePast));
+        $this->inner->expects($this->at(2))
+            ->method('remove')
+            ->with($expiresKey);
+        $this->inner->expects($this->at(3))
+            ->method('remove')
+            ->with($key);
 
-        $this->assertEquals('bar', $this->cache->get('foo'), '->get() returns the cached value');
+        $this->assertNull($this->cache->get($key), '->get() returns null if an expired value exists');
     }
+
+    public function testGetNotExpired()
+    {
+        $key = 'asdf';
+        $expiresKey = 'asdf.expires';
+        $theFuture = time() * 2;
+
+        $this->inner->expects($this->once())
+            ->method('has')
+            ->with($expiresKey)
+            ->will($this->returnValue(true));
+        $this->inner->expects($this->at(1))
+            ->method('get')
+            ->with($expiresKey)
+            ->will($this->returnValue($theFuture));
+        $this->inner->expects($this->at(2))
+            ->method('get')
+            ->with($key)
+            ->will($this->returnValue('bar'));
+                
+        $this->assertEquals('bar', $this->cache->get($key), '->get() returns the cached value');
+    }    
 }


### PR DESCRIPTION
According to the CacheInterface, `get()` should return either the cached value or null.

This is what I have implemented in the `ExpiringCache` (previously get would return the value if even if the entry is outdated).

It is ok ? I have noticed that the `FileSystemCache` and `ConfigCache` throw and an exception which is yet an other behavior.
