### PR TITLE
[CssRewriteFilter] fixes first char of dir name is removed when source an

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -61,7 +61,7 @@ class CssRewriteFilter implements FilterInterface
                         break;
                     }
                 }
-                $path .= substr(dirname($sourceUrl).'/', strlen($targetDir) + 1);
+                $path .= ltrim(substr(dirname($sourceUrl).'/', strlen($targetDir)), '/');
             }
         }
 

--- a/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
+++ b/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
@@ -41,6 +41,7 @@ class CssRewriteFilterTest extends \PHPUnit_Framework_TestCase
             array('body { background: url(\'%s\'); }', 'css/body.css', 'css/build/main.css', '../images/bg.gif', '../../images/bg.gif'),
             array('body { background: url(\'%s\'); }', 'css/body.css', 'main.css', '../images/bg.gif', 'css/../images/bg.gif'), // fixme
             array('body { background: url(\'%s\'); }', 'body.css', 'css/main.css', 'images/bg.gif', '../images/bg.gif'),
+            array('body { background: url(\'%s\'); }', 'source/css/body.css', 'output/build/main.css', '../images/bg.gif', '../../source/images/bg.gif'),
 
             // @import variants
             array('@import "%s";', 'css/imports.css', 'css/build/main.css', 'import.css', '../import.css'),


### PR DESCRIPTION
[CssRewriteFilter] fixes first char of dir name is removed when source and target path have the same depth
