### PR TITLE
My previous pull request also contained these updates, apart from the one

### DIFF
--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -42,7 +42,7 @@ class SassFilter implements FilterInterface
     public function __construct($sassPath = '/usr/bin/sass')
     {
         $this->sassPath = $sassPath;
-        $this->cacheLocation = sys_get_temp_dir();
+        $this->cacheLocation = rtrim(sys_get_temp_dir(), '/\\');
     }
 
     public function setUnixNewlines($unixNewlines)
@@ -157,7 +157,7 @@ class SassFilter implements FilterInterface
         // output
         $options[] = $output = tempnam(sys_get_temp_dir(), 'assetic_sass');
 
-        $proc = new Process(implode(' ', array_map('escapeshellarg', $options)));
+        $proc = new Process(implode(' ', array_map(function($val) { return false === strpos($val, ' ') ? $val : escapeshellarg($val); }, $options)));
         $code = $proc->run();
 
         if (0 < $code) {


### PR DESCRIPTION
My previous pull request also contained these updates, apart from the ones to Process.
Without these, assets dumping (compass files) will fail on Win7 Ultimate.
Changes:
- Strip trailing slashes from the temp path 
- Escape the process arguments only if they contain spaces
