### PR TITLE
CssRewriteFilter to handle absolute path vs relative.

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -35,6 +35,7 @@ class CssRewriteFilter implements FilterInterface
         }
 
         // learn how to get from the target back to the source
+		$host = '';
         if (false !== strpos($sourceBase, '://')) {
             list($scheme, $url) = explode('://', $sourceBase.'/'.$sourcePath, 2);
             list($host, $path) = explode('/', $url, 2);
@@ -42,6 +43,8 @@ class CssRewriteFilter implements FilterInterface
             $host = $scheme.'://'.$host;
             $path = false === strpos($path, '/') ? '' : dirname($path);
             $path .= '/';
+        } else if (0 === strpos($sourcePath, '/')) {
+        	$path = $sourcePath;
         } else {
             // assume source and target are on the same host
             $host = '';


### PR DESCRIPTION
Added a distinction for SourcePath, could be relative or absolute url. If it absolute path, do not try to figure out relative pathing.

if the source path is: images/test
it makes sense that css rewrite changes url to ../../../images/test

But if the source path is: /images/test
css rewrite should not change url to ../../../images/test, instead should be /images/test
