### PR TITLE
Bugfix: Sass Return Code (-1) doesn't trigger RuntimeException

### DIFF
--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -155,7 +155,7 @@ class SassFilter implements FilterInterface
         $code = $proc->run();
         unlink($input);
 
-        if (0 < $code) {
+        if (0 != $code) {
             throw new \RuntimeException($proc->getErrorOutput());
         }
 


### PR DESCRIPTION
The sass command line script likes to return -1 in the case of some failure conditions.  In my case I was missing the compass ruby library, which caused sass to fail.

The return code condition was checking for 0 < $code instead of 0 != $code.  With that modification, a RuntimeException is correctly thrown in the case of a sass failure.
