### PR TITLE
Fixing bug because paths already come back relative

### DIFF
--- a/src/Assetic/Factory/Resource/CoalescingDirectoryResource.php
+++ b/src/Assetic/Factory/Resource/CoalescingDirectoryResource.php
@@ -83,15 +83,11 @@ class CoalescingDirectoryResource implements IteratorResourceInterface
     private function getFileResources()
     {
         $paths = array();
-
         foreach ($this->directories as $directory) {
-            $path = (string) $directory;
-            $offset = strlen($path);
             foreach ($directory as $file) {
                 $pathname = (string) $file;
-                $relative = substr($pathname, $offset);
-                if (!isset($paths[$relative])) {
-                    $paths[$relative] = $file;
+                if (!isset($paths[$pathname])) {
+                    $paths[$pathname] = $file;
                 }
             }
         }


### PR DESCRIPTION
This is/was causing a bug in symfony - many resources weren't being returned, so routes weren't being generated. It appears to have been caused by either https://github.com/kriswallsmith/assetic/commit/a32f4a5201e2e5c9b5996d97bc80374e1bead0cf or https://github.com/kriswallsmith/symfony/commit/a3ed5e3f844aff80855e9afba673ec6b47a09175.

Specifically, since the paths were already relative, the substr returned false, and only one path would be returned per resource.

However, even though this fixes the problem - so that router:debug shows the asset in symfony - the route is still not actually found when you browse to the site or run your tests. I'm hoping this will help someone else recognize why that might be the case.

Thanks!
