### PR TITLE
assetic:dump, lessphp (and may be others) ignored

### DIFF
--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -29,7 +29,7 @@ use Assetic\Asset\AssetInterface;
  */
 class LessphpFilter implements FilterInterface
 {
-    public function filterLoad(AssetInterface $asset)
+    public function filterDump(AssetInterface $asset)
     {
         $root = $asset->getSourceRoot();
         $path = $asset->getSourcePath();
@@ -42,7 +42,7 @@ class LessphpFilter implements FilterInterface
         $asset->setContent($lc->parse($asset->getContent()));
     }
 
-    public function filterDump(AssetInterface $asset)
+    public function filterLoad(AssetInterface $asset)
     {
     }
 }


### PR DESCRIPTION
reverse functions name for lessphp (like CSSmin filters), else assetic:dump ignore lessphp (find in S2 RC4),
may be same problems in others filters.
