### PR TITLE
[Fix] LessFilter does not output all of css tree for large css trees

### DIFF
--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -56,7 +56,6 @@ new(less.Parser)(%s).parse(%s, function(e, tree) {
 
     try {
         sys.print(tree.toCSS(%s));
-        process.exit(0);
     } catch (e) {
         less.writeError(e);
         process.exit(3);


### PR DESCRIPTION
Removing process.exit after sys.print in LessFilter, since sys.print is async.

I've noticed that for large css trees sys.print does not finish outputting the resultant CSS string. It finishes early, and `setTimeout`'s for another time to output the rest of the string -- to the best of my knowledge.  Since it does this, the next line is `process.exit(0)` which interrupts any scheduled timers and exits gracefully. 

Removing the process.exit ensures that `sys.print` finishes.
