### PR TITLE
Added reference to required cssmin library

### DIFF
--- a/src/Assetic/Filter/CssMinFilter.php
+++ b/src/Assetic/Filter/CssMinFilter.php
@@ -14,7 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 
 /**
- * Filters assets through CssMin.
+ * Filters assets through CssMin, which can be found at http://code.google.com/p/cssmin/.
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */


### PR DESCRIPTION
I couldn't find it mentioned anywhere (the location of the PHP cssmin library required). I found an incorrect one with a very close API but it wasn't compatible.
