### PR TITLE
Fix exception message when OptiPNG fails

### DIFF
--- a/src/Assetic/Filter/OptiPngFilter.php
+++ b/src/Assetic/Filter/OptiPngFilter.php
@@ -63,7 +63,7 @@ class OptiPngFilter implements FilterInterface
 
         if (0 < $code) {
             unlink($input);
-            throw new \RuntimeException($proc->getOutput());
+            throw new \RuntimeException($proc->getErrorOutput());
         }
 
         $asset->setContent(file_get_contents($output));


### PR DESCRIPTION
Use stderr for exception message instead of stdout.
