### PR TITLE
Fix rewriting relative urls in external stylesheets.

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -39,7 +39,7 @@ class CssRewriteFilter extends BaseCssFilter
             list($scheme, $url) = explode('://', $sourceBase.'/'.$sourcePath, 2);
             list($host, $path) = explode('/', $url, 2);
 
-            $host = $scheme.'://'.$host;
+            $host = $scheme.'://'.$host . '/';
             $path = false === strpos($path, '/') ? '' : dirname($path);
             $path .= '/';
         } else {


### PR DESCRIPTION
When the cssrewrite filter is used with external files (http://someothersite.com/css/style.css) it would combine the host and the path without a '/' (ie. http://someothersite.comcss/img/myimg.jpg).
