### PR TITLE
Disable coloring

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -39,7 +39,7 @@ class CompassFilter implements FilterInterface
     private $noLineComments;
     private $imagesDir;
     private $javascriptsDir;
-    private $boring;
+    private $boring = false;
 
     // compass configuration file options
     private $plugins = array();


### PR DESCRIPTION
This patch just adds "--boring" to the compassFilter so that Exceptions are readable again. 
At least this happens using symfony's console which adds additional ansi colors which makes the exception not helpful at all.
