### PR TITLE
Fix issue with data URIs with CssRewriteFilter

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -74,6 +74,11 @@ class CssRewriteFilter extends BaseCssFilter
                 return $matches[0];
             }
 
+            if (0 === strpos($matches['url'], 'data:')) {
+                // data uri
+                return $matches[0];
+            }
+
             if ('/' == $matches['url'][0]) {
                 // root relative
                 return str_replace($matches['url'], $host.$matches['url'], $matches[0]);

--- a/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
+++ b/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
@@ -40,6 +40,10 @@ class CssRewriteFilterTest extends \PHPUnit_Framework_TestCase
             array('body { background: url("%s"); }', 'css/body.css', 'css/build/main.css', '../images/bg.gif', '../../images/bg.gif'),
             array('body { background: url(\'%s\'); }', 'css/body.css', 'css/build/main.css', '../images/bg.gif', '../../images/bg.gif'),
 
+            //url with data:
+            array('body { background: url(\'%s\'); }', 'css/body.css', 'css/build/main.css', 'data:image/png;base64,abcdef=', 'data:image/png;base64,abcdef='),
+            array('body { background: url(\'%s\'); }', 'css/body.css', 'css/build/main.css', '../images/bg-data:.gif', '../../images/bg-data:.gif'),
+
             // @import variants
             array('@import "%s";', 'css/imports.css', 'css/build/main.css', 'import.css', '../import.css'),
             array('@import url(%s);', 'css/imports.css', 'css/build/main.css', 'import.css', '../import.css'),


### PR DESCRIPTION
Hi Kris, I have fixed an issue where data URIs with CssRewriteFilter would still be parsed as relative URLs.

If a CSS file is moved and the filter CssRewriteFilter is used, any occurences starting with url('data:') will be transformed as an incorrect new relative path. This branch fixes the issue by adding a very simple conditional and two more assertions.

Hope this helps,
Steven Rosato
