### PR TITLE
adds support for compile-time variables

### DIFF
--- a/src/Assetic/Asset/AssetCache.php
+++ b/src/Assetic/Asset/AssetCache.php
@@ -105,6 +105,21 @@ class AssetCache implements AssetInterface
         return $this->asset->getLastModified();
     }
 
+    public function getVars()
+    {
+        return $this->asset->getVars();
+    }
+
+    public function setValues(array $values)
+    {
+        $this->asset->setValues($values);
+    }
+
+    public function getValues()
+    {
+        return $this->asset->getValues();
+    }
+
     /**
      * Returns a cache key for the current asset.
      *
@@ -136,6 +151,11 @@ class AssetCache implements AssetInterface
 
         foreach ($asset->getFilters() as $filter) {
             $cacheKey .= serialize($filter);
+        }
+
+        if ($values = $asset->getValues()) {
+            asort($values);
+            $cacheKey .= serialize($values);
         }
 
         return md5($cacheKey.$salt);

--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -29,6 +29,8 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     private $targetPath;
     private $content;
     private $clones;
+    private $vars;
+    private $values;
 
     /**
      * Constructor.
@@ -37,7 +39,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
      * @param array  $filters    Filters for the current collection
      * @param string $sourceRoot The root directory
      */
-    public function __construct($assets = array(), $filters = array(), $sourceRoot = null)
+    public function __construct($assets = array(), $filters = array(), $sourceRoot = null, array $vars = array())
     {
         $this->assets = array();
         foreach ($assets as $asset) {
@@ -47,6 +49,8 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
         $this->filters = new FilterCollection($filters);
         $this->sourceRoot = $sourceRoot;
         $this->clones = new \SplObjectStorage();
+        $this->vars = $vars;
+        $this->values = array();
     }
 
     public function all()
@@ -190,5 +194,24 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     public function getIterator()
     {
         return new \RecursiveIteratorIterator(new AssetCollectionFilterIterator(new AssetCollectionIterator($this, $this->clones)));
+    }
+
+    public function getVars()
+    {
+        return $this->vars;
+    }
+
+    public function setValues(array $values)
+    {
+        $this->values = $values;
+
+        foreach ($this as $asset) {
+            $asset->setValues(array_intersect_key($values, array_flip($asset->getVars())));
+        }
+    }
+
+    public function getValues()
+    {
+        return $this->values;
     }
 }

--- a/src/Assetic/Asset/AssetInterface.php
+++ b/src/Assetic/Asset/AssetInterface.php
@@ -132,4 +132,25 @@ interface AssetInterface
      * @return integer|null A UNIX timestamp
      */
     function getLastModified();
+
+    /**
+     * Returns an array of variable names for this asset.
+     *
+     * @return array
+     */
+    function getVars();
+
+    /**
+     * Sets the values for the asset's variables.
+     *
+     * @param array $values
+     */
+    function setValues(array $values);
+
+    /**
+     * Returns the current values for this asset.
+     *
+     * @return array an array of strings
+     */
+    function getValues();
 }

--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -99,6 +99,21 @@ class AssetReference implements AssetInterface
         return $this->callAsset(__FUNCTION__);
     }
 
+    public function getVars()
+    {
+        return $this->callAsset(__FUNCTION__);
+    }
+
+    public function getValues()
+    {
+        return $this->callAsset(__FUNCTION__);
+    }
+
+    public function setValues(array $values)
+    {
+        $this->callAsset(__FUNCTION__, array($values));
+    }
+
     // private
 
     private function callAsset($method, $arguments = array())

--- a/src/Assetic/Asset/BaseAsset.php
+++ b/src/Assetic/Asset/BaseAsset.php
@@ -30,17 +30,21 @@ abstract class BaseAsset implements AssetInterface
     private $targetPath;
     private $content;
     private $loaded;
+    private $vars;
+    private $values;
 
     /**
      * Constructor.
      *
      * @param array $filters Filters for the asset
      */
-    public function __construct($filters = array(), $sourceRoot = null, $sourcePath = null)
+    public function __construct($filters = array(), $sourceRoot = null, $sourcePath = null, array $vars = array())
     {
         $this->filters = new FilterCollection($filters);
         $this->sourceRoot = $sourceRoot;
         $this->sourcePath = $sourcePath;
+        $this->vars = $vars;
+        $this->values = array();
         $this->loaded = false;
     }
 
@@ -130,6 +134,36 @@ abstract class BaseAsset implements AssetInterface
 
     public function setTargetPath($targetPath)
     {
+        if ($this->vars) {
+            foreach ($this->vars as $var) {
+                if (false === strpos($targetPath, $var)) {
+                    throw new \RuntimeException(sprintf('The asset target path "%s" must contain the variable "{%s}".', $targetPath, $var));
+                }
+            }
+        }
+
         $this->targetPath = $targetPath;
+    }
+
+    public function getVars()
+    {
+        return $this->vars;
+    }
+
+    public function setValues(array $values)
+    {
+        foreach ($values as $var => $v) {
+            if (!in_array($var, $this->vars, true)) {
+                throw new \InvalidArgumentException(sprintf('The asset with source path "%s" has no variable named "%s".', $this->sourcePath, $var));
+            }
+        }
+
+        $this->values = $values;
+        $this->loaded = false;
+    }
+
+    public function getValues()
+    {
+        return $this->values;
     }
 }

--- a/src/Assetic/Asset/FileAsset.php
+++ b/src/Assetic/Asset/FileAsset.php
@@ -11,6 +11,7 @@
 
 namespace Assetic\Asset;
 
+use Assetic\Util\PathUtils;
 use Assetic\Filter\FilterInterface;
 
 /**
@@ -32,7 +33,7 @@ class FileAsset extends BaseAsset
      *
      * @throws InvalidArgumentException If the supplied root doesn't match the source when guessing the path
      */
-    public function __construct($source, $filters = array(), $sourceRoot = null, $sourcePath = null)
+    public function __construct($source, $filters = array(), $sourceRoot = null, $sourcePath = null, array $vars = array())
     {
         if (null === $sourceRoot) {
             $sourceRoot = dirname($source);
@@ -49,12 +50,19 @@ class FileAsset extends BaseAsset
 
         $this->source = $source;
 
-        parent::__construct($filters, $sourceRoot, $sourcePath);
+        parent::__construct($filters, $sourceRoot, $sourcePath, $vars);
     }
 
     public function load(FilterInterface $additionalFilter = null)
     {
-        $this->doLoad(file_get_contents($this->source), $additionalFilter);
+        $source = PathUtils::resolvePath($this->source, $this->getVars(),
+            $this->getValues());
+
+        if (!is_file($source)) {
+            throw new \RuntimeException(sprintf('The source file "%s" does not exist.', $source));
+        }
+
+        $this->doLoad(file_get_contents($source), $additionalFilter);
     }
 
     public function getLastModified()

--- a/src/Assetic/Asset/GlobAsset.php
+++ b/src/Assetic/Asset/GlobAsset.php
@@ -11,6 +11,8 @@
 
 namespace Assetic\Asset;
 
+use Assetic\Util\PathUtils;
+
 use Assetic\Filter\FilterInterface;
 
 /**
@@ -30,12 +32,12 @@ class GlobAsset extends AssetCollection
      * @param array        $filters An array of filters
      * @param string       $root    The root directory
      */
-    public function __construct($globs, $filters = array(), $root = null)
+    public function __construct($globs, $filters = array(), $root = null, array $vars = array())
     {
         $this->globs = (array) $globs;
         $this->initialized = false;
 
-        parent::__construct(array(), $filters, $root);
+        parent::__construct(array(), $filters, $root, $vars);
     }
 
     public function all()
@@ -83,12 +85,20 @@ class GlobAsset extends AssetCollection
         return parent::getIterator();
     }
 
+    public function setValues(array $values)
+    {
+        parent::setValues($values);
+        $this->initialized = false;
+    }
+
     /**
      * Initializes the collection based on the glob(s) passed in.
      */
     private function initialize()
     {
         foreach ($this->globs as $glob) {
+            $glob = PathUtils::resolvePath($glob, $this->getVars(), $this->getValues());
+
             if (false !== $paths = glob($glob)) {
                 foreach ($paths as $path) {
                     $this->add(new FileAsset($path, array(), $this->getSourceRoot()));

--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -11,6 +11,8 @@
 
 namespace Assetic\Asset;
 
+use Assetic\Util\PathUtils;
+
 use Assetic\Filter\FilterInterface;
 
 /**
@@ -31,7 +33,7 @@ class HttpAsset extends BaseAsset
      *
      * @throws InvalidArgumentException If the first argument is not an URL
      */
-    public function __construct($sourceUrl, $filters = array(), $ignoreErrors = false)
+    public function __construct($sourceUrl, $filters = array(), $ignoreErrors = false, array $vars = array())
     {
         if (0 === strpos($sourceUrl, '//')) {
             $sourceUrl = 'http:'.$sourceUrl;
@@ -45,12 +47,13 @@ class HttpAsset extends BaseAsset
         list($scheme, $url) = explode('://', $sourceUrl, 2);
         list($host, $path) = explode('/', $url, 2);
 
-        parent::__construct($filters, $scheme.'://'.$host, $path);
+        parent::__construct($filters, $scheme.'://'.$host, $path, $vars);
     }
 
     public function load(FilterInterface $additionalFilter = null)
     {
-        if (false === $content = @file_get_contents($this->sourceUrl)) {
+        if (false === $content = @file_get_contents(PathUtils::resolvePath(
+                $this->sourceUrl, $this->getVars(), $this->getValues()))) {
             if ($this->ignoreErrors) {
                 return;
             } else {

--- a/src/Assetic/AssetWriter.php
+++ b/src/Assetic/AssetWriter.php
@@ -11,25 +11,38 @@
 
 namespace Assetic;
 
+use Assetic\Util\PathUtils;
+
 use Assetic\Asset\AssetInterface;
 
 /**
  * Writes assets to the filesystem.
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class AssetWriter
 {
     private $dir;
+    private $varValues;
 
     /**
      * Constructor.
      *
      * @param string $dir The base web directory
      */
-    public function __construct($dir)
+    public function __construct($dir, array $varValues = array())
     {
+        foreach ($varValues as $var => $values) {
+            foreach ($values as $value) {
+                if (!is_string($value)) {
+                    throw new \InvalidArgumentException(sprintf('All variable values must be strings, but got %s for variable "%s".', json_encode($value), $var));
+                }
+            }
+        }
+
         $this->dir = $dir;
+        $this->varValues = $varValues;
     }
 
     public function writeManagerAssets(AssetManager $am)
@@ -41,7 +54,44 @@ class AssetWriter
 
     public function writeAsset(AssetInterface $asset)
     {
-        static::write($this->dir . '/' . $asset->getTargetPath(), $asset->dump());
+        foreach ($this->getCombinations($asset->getVars()) as $combination) {
+            $asset->setValues($combination);
+
+            static::write($this->dir.'/'.PathUtils::resolvePath(
+                $asset->getTargetPath(), $asset->getVars(), $asset->getValues()),
+                $asset->dump());
+        }
+    }
+
+    private function getCombinations(array $vars)
+    {
+        if (!$vars) {
+            return array(array());
+        }
+
+        $combinations = array();
+        $nbValues = array();
+        foreach ($this->varValues as $var => $values) {
+            if (!in_array($var, $vars, true)) {
+                continue;
+            }
+
+            $nbValues[$var] = count($values);
+        }
+
+        for ($i=array_product($nbValues),$c=$i*2; $i<$c; $i++) {
+            $k = $i;
+            $combination = array();
+
+            foreach ($vars as $var) {
+                $combination[$var] = $this->varValues[$var][$k % $nbValues[$var]];
+                $k = intval($k/$nbValues[$var]);
+            }
+
+            $combinations[] = $combination;
+        }
+
+        return $combinations;
     }
 
     static protected function write($path, $contents)

--- a/src/Assetic/Extension/Twig/AsseticExtension.php
+++ b/src/Assetic/Extension/Twig/AsseticExtension.php
@@ -11,17 +11,20 @@
 
 namespace Assetic\Extension\Twig;
 
+use Assetic\ValueSupplierInterface;
 use Assetic\Factory\AssetFactory;
 
 class AsseticExtension extends \Twig_Extension
 {
     protected $factory;
     protected $functions;
+    protected $valueSupplier;
 
-    public function __construct(AssetFactory $factory, $functions = array())
+    public function __construct(AssetFactory $factory, $functions = array(), ValueSupplierInterface $valueSupplier = null)
     {
         $this->factory = $factory;
         $this->functions = array();
+        $this->valueSupplier = $valueSupplier;
 
         foreach ($functions as $function => $options) {
             if (is_integer($function) && is_string($options)) {
@@ -54,7 +57,10 @@ class AsseticExtension extends \Twig_Extension
     public function getGlobals()
     {
         return array(
-            'assetic' => array('debug' => $this->factory->isDebug()),
+            'assetic' => array(
+                'debug' => $this->factory->isDebug(),
+                'vars'  => null !== $this->valueSupplier ? $this->valueSupplier->getValues() : array(),
+            ),
         );
     }
 

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -51,6 +51,7 @@ class AsseticTokenParser extends \Twig_TokenParser
         $attributes = array(
             'output'   => $this->output,
             'var_name' => 'asset_url',
+            'vars'     => array(),
         );
 
         $stream = $this->parser->getStream();
@@ -88,6 +89,23 @@ class AsseticTokenParser extends \Twig_TokenParser
                 $stream->next();
                 $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
                 $attributes['combine'] = 'true' == $stream->expect(\Twig_Token::NAME_TYPE, array('true', 'false'))->getValue();
+            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'vars')) {
+                // vars=['locale','browser']
+                $stream->next();
+                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
+                $stream->expect(\Twig_Token::PUNCTUATION_TYPE, '[');
+
+                while ($stream->test(\Twig_Token::STRING_TYPE)) {
+                    $attributes['vars'][] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+
+                    if (!$stream->test(\Twig_Token::PUNCTUATION_TYPE, ',')) {
+                        break;
+                    }
+
+                    $stream->next();
+                }
+
+                $stream->expect(\Twig_Token::PUNCTUATION_TYPE, ']');
             } elseif ($stream->test(\Twig_Token::NAME_TYPE, $this->extensions)) {
                 // an arbitrary configured attribute
                 $key = $stream->next()->getValue();

--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -58,6 +58,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
                     'name'    => $node->getAttribute('name'),
                     'debug'   => $node->getAttribute('debug'),
                     'combine' => $node->getAttribute('combine'),
+                    'vars'    => $node->getAttribute('vars'),
                 ),
             );
         } elseif ($node instanceof \Twig_Node_Expression_Function) {

--- a/src/Assetic/Util/PathUtils.php
+++ b/src/Assetic/Util/PathUtils.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Assetic\Util;
+
+/**
+ * Path Utils.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class PathUtils
+{
+    public static function resolvePath($path, array $vars, array $values)
+    {
+        $map = array();
+        foreach ($vars as $var) {
+            if (false === strpos($path, '{'.$var.'}')) {
+                continue;
+            }
+
+            if (!isset($values[$var])) {
+                throw new \InvalidArgumentException(sprintf('The path "%s" contains the variable "%s", but was not given any value for it.', $path, $var));
+            }
+
+            $map['{'.$var.'}'] = $values[$var];
+        }
+
+        return strtr($path, $map);
+    }
+
+    private final function __construct() { }
+}

--- a/src/Assetic/ValueSupplierInterface.php
+++ b/src/Assetic/ValueSupplierInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2011 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic;
+
+/**
+ * Value Supplier Interface.
+ *
+ * Implementations determine runtime values for compile-time variables.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface ValueSupplierInterface
+{
+    /**
+     * Returns a map of values.
+     *
+     * @return array
+     */
+    function getValues();
+}

--- a/tests/Assetic/Test/Asset/HttpAssetTest.php
+++ b/tests/Assetic/Test/Asset/HttpAssetTest.php
@@ -19,6 +19,10 @@ class HttpAssetTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLastModified()
     {
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('The OpenSSL extension is not loaded.');
+        }
+        
         $asset = new HttpAsset(self::JQUERY);
         $this->assertInternalType('integer', $asset->getLastModified(), '->getLastModified() returns an integer');
     }

--- a/tests/Assetic/Test/AssetWriterTest.php
+++ b/tests/Assetic/Test/AssetWriterTest.php
@@ -11,6 +11,9 @@
 
 namespace Assetic\Test;
 
+use Assetic\Asset\FileAsset;
+
+use Assetic\AssetManager;
 use Assetic\AssetWriter;
 
 class AssetWriterTest extends \PHPUnit_Framework_TestCase
@@ -19,7 +22,11 @@ class AssetWriterTest extends \PHPUnit_Framework_TestCase
     {
         $this->dir = sys_get_temp_dir().'/assetic_tests_'.rand(11111, 99999);
         mkdir($this->dir);
-        $this->writer = new AssetWriter($this->dir);
+        $this->writer = new AssetWriter($this->dir, array(
+            'locale' => array('en', 'de', 'fr'),
+            'browser' => array('ie', 'firefox', 'other'),
+            'gzip' => array('gzip', '')
+        ));
     }
 
     protected function tearDown()
@@ -40,16 +47,160 @@ class AssetWriterTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with('foo')
             ->will($this->returnValue($asset));
-        $asset->expects($this->once())
+        $asset->expects($this->atLeastOnce())
             ->method('getTargetPath')
             ->will($this->returnValue('target_url'));
         $asset->expects($this->once())
             ->method('dump')
             ->will($this->returnValue('content'));
+        $asset->expects($this->atLeastOnce())
+            ->method('getVars')
+            ->will($this->returnValue(array()));
+        $asset->expects($this->atLeastOnce())
+            ->method('getValues')
+            ->will($this->returnValue(array()));
 
         $this->writer->writeManagerAssets($am);
 
         $this->assertFileExists($this->dir.'/target_url');
         $this->assertEquals('content', file_get_contents($this->dir.'/target_url'));
+    }
+
+    public function testWriteAssetWithVars()
+    {
+        $asset = $this->getMock('Assetic\Asset\AssetInterface');
+        $asset->expects($this->atLeastOnce())
+            ->method('getVars')
+            ->will($this->returnValue(array('locale')));
+
+        $self = $this;
+        $expectedValues = array(
+            array('locale' => 'en'),
+            array('locale' => 'de'),
+            array('locale' => 'fr'),
+        );
+        $asset->expects($this->exactly(3))
+            ->method('setValues')
+            ->will($this->returnCallback(function($values) use($self, $expectedValues) {
+                static $counter = 0;
+                $self->assertEquals($expectedValues[$counter++], $values);
+            }));
+        $asset->expects($this->exactly(3))
+            ->method('getValues')
+            ->will($this->returnCallback(function() use($expectedValues) {
+                static $counter = 0;
+                return $expectedValues[$counter++];
+            }));
+
+        $asset->expects($this->exactly(3))
+            ->method('dump')
+            ->will($this->onConsecutiveCalls('en', 'de', 'fr'));
+
+        $asset->expects($this->atLeastOnce())
+            ->method('getTargetPath')
+            ->will($this->returnValue('target.{locale}'));
+
+        $this->writer->writeAsset($asset);
+
+        $this->assertFileExists($this->dir.'/target.en');
+        $this->assertFileExists($this->dir.'/target.de');
+        $this->assertFileExists($this->dir.'/target.fr');
+        $this->assertEquals('en', file_get_contents($this->dir.'/target.en'));
+        $this->assertEquals('de', file_get_contents($this->dir.'/target.de'));
+        $this->assertEquals('fr', file_get_contents($this->dir.'/target.fr'));
+    }
+
+    public function testAssetWithInputVars()
+    {
+        $asset = new FileAsset(__DIR__.'/Fixture/messages.{locale}.js',
+            array(), null, null, array('locale'));
+        $asset->setTargetPath('messages.{locale}.js');
+
+        $this->writer->writeAsset($asset);
+
+        $this->assertFileExists($this->dir.'/messages.en.js');
+        $this->assertFileExists($this->dir.'/messages.de.js');
+        $this->assertFileExists($this->dir.'/messages.fr.js');
+        $this->assertEquals('var messages = {"text.greeting": "Hello %name%!"};',
+            file_get_contents($this->dir.'/messages.en.js'));
+        $this->assertEquals('var messages = {"text.greeting": "Hallo %name%!"};',
+            file_get_contents($this->dir.'/messages.de.js'));
+        $this->assertEquals('var messages = {"text.greet": "All\u00f4 %name%!"};',
+            file_get_contents($this->dir.'/messages.fr.js'));
+    }
+
+    /**
+     * @dataProvider getCombinationTests
+     */
+    public function testGetCombinations($vars, $expectedCombinations)
+    {
+        $ref = new \ReflectionMethod($this->writer, 'getCombinations');
+        $ref->setAccessible(true);
+
+        $this->assertEquals($expectedCombinations, $ref->invoke($this->writer, $vars));
+    }
+
+    public function getCombinationTests()
+    {
+        $tests = array();
+
+        // no variables
+        $tests[] = array(
+            array(),
+            array(array())
+        );
+
+        // one variables
+        $tests[] = array(
+            array('locale'),
+            array(
+                array('locale' => 'en'),
+                array('locale' => 'de'),
+                array('locale' => 'fr'),
+            )
+        );
+
+        // two variables
+        $tests[] = array(
+            array('locale', 'browser'),
+            array(
+                array('locale' => 'en', 'browser' => 'ie'),
+                array('locale' => 'de', 'browser' => 'ie'),
+                array('locale' => 'fr', 'browser' => 'ie'),
+                array('locale' => 'en', 'browser' => 'firefox'),
+                array('locale' => 'de', 'browser' => 'firefox'),
+                array('locale' => 'fr', 'browser' => 'firefox'),
+                array('locale' => 'en', 'browser' => 'other'),
+                array('locale' => 'de', 'browser' => 'other'),
+                array('locale' => 'fr', 'browser' => 'other'),
+            )
+        );
+
+        // three variables
+        $tests[] = array(
+            array('locale', 'browser', 'gzip'),
+            array(
+                array('locale' => 'en', 'browser' => 'ie', 'gzip' => 'gzip'),
+                array('locale' => 'de', 'browser' => 'ie', 'gzip' => 'gzip'),
+                array('locale' => 'fr', 'browser' => 'ie', 'gzip' => 'gzip'),
+                array('locale' => 'en', 'browser' => 'firefox', 'gzip' => 'gzip'),
+                array('locale' => 'de', 'browser' => 'firefox', 'gzip' => 'gzip'),
+                array('locale' => 'fr', 'browser' => 'firefox', 'gzip' => 'gzip'),
+                array('locale' => 'en', 'browser' => 'other', 'gzip' => 'gzip'),
+                array('locale' => 'de', 'browser' => 'other', 'gzip' => 'gzip'),
+                array('locale' => 'fr', 'browser' => 'other', 'gzip' => 'gzip'),
+                array('locale' => 'en', 'browser' => 'ie', 'gzip' => ''),
+                array('locale' => 'de', 'browser' => 'ie', 'gzip' => ''),
+                array('locale' => 'fr', 'browser' => 'ie', 'gzip' => ''),
+                array('locale' => 'en', 'browser' => 'firefox', 'gzip' => ''),
+                array('locale' => 'de', 'browser' => 'firefox', 'gzip' => ''),
+                array('locale' => 'fr', 'browser' => 'firefox', 'gzip' => ''),
+                array('locale' => 'en', 'browser' => 'other', 'gzip' => ''),
+                array('locale' => 'de', 'browser' => 'other', 'gzip' => ''),
+                array('locale' => 'fr', 'browser' => 'other', 'gzip' => ''),
+            )
+        );
+
+        return $tests;
     }
 }

--- a/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
+++ b/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
@@ -58,6 +58,7 @@ class TwigFormulaLoaderTest extends \PHPUnit_Framework_TestCase
                     'name'    => 'mixture',
                     'debug'   => false,
                     'combine' => null,
+                    'vars'    => array(),
                 ),
             ),
         );

--- a/tests/Assetic/Test/Extension/Twig/templates/variables.twig
+++ b/tests/Assetic/Test/Extension/Twig/templates/variables.twig
@@ -1,0 +1,5 @@
+<assets>
+    {% javascripts "foo.js" "variable_input.{foo}.js" vars=["foo", "bar"] debug=true %}
+    <url>{{ asset_url }}</url>
+    {% endjavascripts %}
+</assets>

--- a/tests/Assetic/Test/Factory/Resource/CoalescingDirectoryResourceTest.php
+++ b/tests/Assetic/Test/Factory/Resource/CoalescingDirectoryResourceTest.php
@@ -29,14 +29,14 @@ class CoalescingDirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
         $paths = array();
         foreach ($resource as $file) {
-            $paths[] = (string) $file;
+            $paths[] = realpath((string) $file);
         }
         sort($paths);
 
         $this->assertEquals(array(
-            __DIR__.'/Fixtures/dir1/file1.txt',
-            __DIR__.'/Fixtures/dir1/file2.txt',
-            __DIR__.'/Fixtures/dir2/file3.txt',
+            realpath(__DIR__.'/Fixtures/dir1/file1.txt'),
+            realpath(__DIR__.'/Fixtures/dir1/file2.txt'),
+            realpath(__DIR__.'/Fixtures/dir2/file3.txt'),
         ), $paths, 'files from multiple directories are merged');
     }
 }

--- a/tests/Assetic/Test/Fixture/messages.de.js
+++ b/tests/Assetic/Test/Fixture/messages.de.js
@@ -1,0 +1,1 @@
+var messages = {"text.greeting": "Hallo %name%!"};

--- a/tests/Assetic/Test/Fixture/messages.en.js
+++ b/tests/Assetic/Test/Fixture/messages.en.js
@@ -1,0 +1,1 @@
+var messages = {"text.greeting": "Hello %name%!"};

--- a/tests/Assetic/Test/Fixture/messages.fr.js
+++ b/tests/Assetic/Test/Fixture/messages.fr.js
@@ -1,0 +1,1 @@
+var messages = {"text.greet": "All\u00f4 %name%!"};


### PR DESCRIPTION
This adds support for compile-time variables to assets. For example, if you want to compile an asset for a specific locale/browser, then you could write something like this:

``` html+jinja
{% javascripts "foo.js" vars=["locale","browser"] %}
<script language="javascript" type="text/javascript" src="{{ asset_url }}"></script>
{% endjavascripts %}
```

``` yml
# define all possible values for each variable
assetic:
    variables:
        locale: ["en", "de"]
        browser: ["ie", "other"]
```

``` php
<?php

use Assetic\ValueSupplierInterface;

class MyValueSupplier implements ValueSupplierInterface
{
    private $container;

    public function __construct(ContainerInterface $container)
    {
        $this->container = $container;
    }

    public function getValues()
    {
        $request = $this->container->get('request');       
        $client = /** some nice method to get the client from the request */;  

        return array(
            'locale' => $request->getLocale(),
            'browser' => $client,
        );
    }
}
```

I've only worked on Twig support (not sure how much of this is possible with PHP). I'll also open a PR on the AsseticBundle to add support for this.
