### PR TITLE
Compass problem on Windows, ruby.exe not found

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -263,9 +263,6 @@ class CompassFilter implements FilterInterface
         // output
         $output = $tempName.'.css';
 
-        // it's not really usefull but... https://github.com/chriseppstein/compass/issues/376
-        $pb->setEnv('HOME', sys_get_temp_dir());
-
         $proc = $pb->getProcess();
         $code = $proc->run();
 


### PR DESCRIPTION
I stumbled on an issue with the compass filter on Windows. The `SassFilter` was working correctly but the `CompassFilter` was always given me an error:

```
'"ruby.exe"' is not recognized as an internal or external command, operable program or batch file.
```

I found this bizarre since `sass` is using ruby also and was working correctly. After some research, I noticed that in `CompassFilter`, the environment `HOME` was being set to resolve a potential bug of Compass. Since the `HOME` variable is set, the environment is not NULL anymore in the process and the process doesn't inherits variables from the PHP process. This was then causing the problem where ruby is not found because it was not in the `PATH` anymore.

To fix this, I removed the call to `$pb->setEnv('HOME', sys_get_temp_dir());` since the problem about homeless user seems is resolved in the latest version of `Compass`.

Another possible fix, if we still need to set the `HOME` variable, is to add the PATH environment variable. I implemented this fix in this [branch](https://github.com/maoueh/assetic/tree/patch-compass-windows-add-path) of my assetic fork.

To make it fully work, I had to add the fix found in issue #152. This is another issue but it worth mentionning for those who would like to get it working on windows. This [branch](https://github.com/maoueh/assetic/tree/patch-compass) from my assetic fork combine those two fixes.

Regards,
Matt
