### PR TITLE
Fixed @import using lessphp filter and relative paths

### DIFF
--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -34,12 +34,9 @@ class LessphpFilter implements FilterInterface
         $root = $asset->getSourceRoot();
         $path = $asset->getSourcePath();
 
-        $lc = new \lessc();
-        if ($root && $path) {
-            $lc->importDir = dirname($root.'/'.$path);
-        }
+        $lc = new \lessc($root.'/'.$path);
 
-        $asset->setContent($lc->parse($asset->getContent()));
+        $asset->setContent($lc->parse());
     }
 
     public function filterDump(AssetInterface $asset)


### PR DESCRIPTION
Changed filterLoad() to use lessphp's built in loading of files. This allows @import of .less files to work correctly with paths relative to the .less file being loaded.
