### PR TITLE
Ability to pass variables into lessphp filter

### DIFF
--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -29,19 +29,14 @@ use Assetic\Asset\AssetInterface;
  */
 class LessphpFilter implements FilterInterface
 {
-    private $presets;
+    private $presets = array();
 
-     /**
-     * Constructor.
-     *
-     * @param array $presets An array of pre-defined variables
-     */
-    public function __construct(array $presets = array())
+    public function setPresets(array $presets)
     {
         $this->presets = $presets;
     }
 
-   public function filterLoad(AssetInterface $asset)
+    public function filterLoad(AssetInterface $asset)
     {
         $root = $asset->getSourceRoot();
         $path = $asset->getSourcePath();


### PR DESCRIPTION
This is a very simple enhancement that lets pass variables into the less file from php (using the already existing functionality):
http://leafo.net/lessphp/docs/#setting_variables_from_php

I also concerned about the ability to set these variables from config.yml, this requires [appropriate changes](https://github.com/symfony/AsseticBundle/pull/74) in AsseticBundle.

I suppose an example to call lessphp:

```
assetic:
    filters:
        lessphp:
            presets:
                baseColor:      '#f00'
                anotherColor:   '#0f0'
                imagePrefix:    'http://cdn.example.com/img/'
```
