### PR TITLE
Compass and CSS input files

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -237,6 +237,12 @@ class CompassFilter implements FilterInterface
             $optionsConfig['http_javascripts_path'] = $this->httpJavascriptsPath;
         }
 
+        // compass should only parse sass and scss files
+        $type = pathinfo($path, PATHINFO_EXTENSION);
+        if ('sass' != $type && 'scss' != $type) {
+            return;
+        }
+
         // options in configuration file
         if (count($optionsConfig)) {
             $config = array();
@@ -257,16 +263,6 @@ class CompassFilter implements FilterInterface
         }
 
         $pb->add('--sass-dir')->add('')->add('--css-dir')->add('');
-
-        // compass choose the type (sass or scss from the filename)
-        if (null !== $this->scss) {
-            $type = $this->scss ? 'scss' : 'sass';
-        } elseif ($path) {
-            // FIXME: what if the extension is something else?
-            $type = pathinfo($path, PATHINFO_EXTENSION);
-        } else {
-            $type = 'scss';
-        }
 
         $tempName = tempnam($tempDir, 'assetic_compass');
         unlink($tempName); // FIXME: don't use tempnam() here


### PR DESCRIPTION
I tried to create a single css from alot of scss (own) and css (jquery-ui) files by using twig:

``` twig
{% stylesheets filter="compass,?yui_css" output="combined/the.css"
    "@SomeSiteBundle/Resources/public/css/base.scss"
    "@SomeSiteBundle/Resources/public/css/jquery-ui/jquery.ui.core.css"
    "@SomeSiteBundle/Resources/public/css/jquery-ui/jquery.ui.theme.css"
%}
<link rel="stylesheet" type="text/css" media="screen" href="{{ asset_url }}" />
{% endstylesheets %}
```

But it did not work and gave me lots of

 [RuntimeException]
 WARNING on line 12 of /tmp/assetic_compass9Aiq7d.css:
 This selector doesn't have any properties and will not be rendered.

so instead of making two stylesheet-blocks i looked through the CompassFilter and noticed that it should only accept sass and scss files, but in fact accepted all file extensions. From my understanding compass should only handle those files but i might be wrong.

Also it seems that $this->scss is never set, not even by the setScss-method but i left it unchanged. Moved the check above the config file construction so no cleanup is needed.
