### PR TITLE
Added a memcached cache adapter using pecl/memcached

### DIFF
--- a/src/Assetic/Cache/MemcachedCache.php
+++ b/src/Assetic/Cache/MemcachedCache.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2011 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Cache;
+
+/**
+ * Uses pecl/memcached to cache files in memcached
+ *
+ * @author Christer Edvartsen <cogo@starzinger.net>
+ */
+class MemcachedCache implements CacheInterface
+{
+    /**
+     * @var int
+     */
+    public $ttl = 0;
+
+    /**
+     * @var Memcached
+     */
+    private $memcached;
+
+    /**
+     * Class constructor
+     *
+     * @param Memcached $memcached Instance of pecl/memcached
+     */
+    public function __construct(\Memcached $memcached)
+    {
+        $this->memcached = $memcached;
+    }
+
+    /**
+     * @see CacheInterface::has()
+     */
+    public function has($key)
+    {
+        return false !== $this->memcached->get($key);
+    }
+
+    /**
+     * @see CacheInterface::get()
+     */
+    public function get($key)
+    {
+        $value = $this->memcached->get($key);
+
+        if (!$value) {
+            $value = null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @see CacheInterface::set()
+     */
+    public function set($key, $value)
+    {
+        return $this->memcached->set($key, $value, $this->ttl);
+    }
+
+    /**
+     * @see CacheInterface::remove()
+     */
+    public function remove($key)
+    {
+        return $this->memcached->delete($key);
+    }
+}

--- a/tests/Assetic/Test/Cache/MemcachedCacheTest.php
+++ b/tests/Assetic/Test/Cache/MemcachedCacheTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2011 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Cache;
+
+use Assetic\Cache\MemcachedCache;
+
+/**
+ * @group integration
+ */
+class MemcachedCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCache()
+    {
+        $memcached = $this->getMock('Memcached');
+
+        $memcached->expects($this->any())->method('get')->with('foo')->will($this->onConsecutiveCalls(
+            false, // First call to MemcachedCache::has
+            'bar', // First call to MemcachedCache::get
+            'bar', // Second call to MemcachedCache::has
+            false  // Third call to MemcachedCache::has
+        ));
+
+        $memcached->expects($this->once())->method('set')->with('foo', 'bar')->will($this->returnValue(true));
+        $memcached->expects($this->once())->method('delete')->with('foo')->will($this->returnValue(true));
+
+        $cache = new MemcachedCache($memcached);
+
+        $this->assertFalse($cache->has('foo'));
+        $this->assertTrue($cache->set('foo', 'bar'));
+        $this->assertEquals('bar', $cache->get('foo'));
+
+        $this->assertTrue($cache->has('foo'));
+
+        $this->assertTrue($cache->remove('foo'));
+        $this->assertFalse($cache->has('foo'));
+    }
+
+    public function testGetReturnsNullIfKeyDoesNotExist() {
+        $memcached = $this->getMock('Memcached');
+
+        $memcached->expects($this->once())->method('get')->with('key')->will($this->returnValue(false));
+
+        $cache = new MemcachedCache($memcached);
+
+        $this->assertNull($cache->get('key'));
+    }
+}


### PR DESCRIPTION
This pull request includes a cache adapter based on pecl/memcached that caches to memcached. This would work nice for users having several backend servers that all could write to/fetch from the same memcached server(s).

The actual memcached instance is hard to generalise, so it should be created outside and simply passed in to the adapter.
