### PR TITLE
Add the way to contact closure compiler API using curl, if available

### DIFF
--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -57,7 +57,7 @@ class CompilerApiFilter extends BaseCompilerFilter
             $query['warning_level'] = $this->warningLevel;
         }
 
-        if(preg_match('/1|yes|on|true/i', ini_get('allow_url_fopen'))){
+        if (preg_match('/1|yes|on|true/i', ini_get('allow_url_fopen'))) {
             $context = stream_context_create(array('http' => array(
                 'method'  => 'POST',
                 'header'  => 'Content-Type: application/x-www-form-urlencoded',
@@ -67,7 +67,7 @@ class CompilerApiFilter extends BaseCompilerFilter
             $response = file_get_contents('http://closure-compiler.appspot.com/compile', false, $context);
             $data = json_decode($response);
 
-         } elseif (defined('CURLOPT_POST') && !in_array($function, explode(',', ini_get('disable_functions')))) {
+         } elseif (defined('CURLOPT_POST') && !in_array('curl_init', explode(',', ini_get('disable_functions')))) {
 
             $ch = curl_init('http://closure-compiler.appspot.com/compile');
             curl_setopt($ch, CURLOPT_POST, true);
@@ -79,10 +79,8 @@ class CompilerApiFilter extends BaseCompilerFilter
             curl_close($ch);
 
             $data = json_decode($response);
-        }else{
-            // @codeCoverageIgnoreStart
+        } else {
             throw new \RuntimeException("There is no known way to contact closure compiler available");
-            // @codeCoverageIgnoreEnd
         }
 
         if (isset($data->serverErrors) && 0 < count($data->serverErrors)) {


### PR DESCRIPTION
With this addition to the google closure compiler API, if allow_url_fopen is set
to false, it tries to accessing closure compiler using curl.
Note that most free servers have allow_url_fopen set to false and many (a huge
amount of them) have curl turned on.

With this we can deliver closure compiler capabilities to more assetic users than the previous version
