### PR TITLE
In Debug mode, use actual CSS source paths, rather than rename one-to-one

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticNode.php
+++ b/src/Assetic/Extension/Twig/AsseticNode.php
@@ -91,11 +91,36 @@ class AsseticNode extends \Twig_Node
     }
 
     protected function compileDebug(\Twig_Compiler $compiler)
-    {
+    {  
         $i = 0;
         foreach ($this->getAttribute('asset') as $leaf) {
+            $useSource  = (pathinfo($leaf->getSourcePath(), PATHINFO_EXTENSION) == 'css');
+
+            if ($useSource) { 
+              $compiler
+                ->write("if (isset(\$context['assetic']['debug']) && \$context['assetic']['debug']) {\n")
+                ->indent()
+                  ->write('$context[')
+                  ->repr($this->getAttribute('var_name'))
+                  ->raw("] = '/")
+                  ->raw($leaf->getSourcePath())
+                  ->raw("';\n")
+                  ->subcompile($this->getNode('body'))
+                ->outdent()
+                ->write("} else {\n")
+                ->indent()
+              ;
+            }
+
             $leafName = $this->getAttribute('name').'_'.$i++;
             $this->compileAsset($compiler, $leaf, $leafName);
+
+            if ($useSource) { 
+              $compiler
+                  ->outdent()
+                  ->write("}\n")
+              ;
+            }
         }
     }
 


### PR DESCRIPTION
When using a live CSS editor like Expresso, it's critical that the actual CSS files are being referred to, so that @override works properly and the right files are edited on disk. So, in Debug mode, rather than output an one-to-one renamed asset, for each css input file we can just refer to the original files.

This patch may be a problem if the source CSS files are not accessible in the web tree, so possibly this could be controlled by an option other than assetic.debug (eg, assetic.debug.use_source_css).

Hope some version of this can be accepted, right now our CSS work is back to the old "edit file -> refresh" cycle, and the frontend guys are driving us nuts. ;)
