### PR TITLE
Added HashableInterface for filters that can't be serialized

### DIFF
--- a/src/Assetic/Asset/AssetCache.php
+++ b/src/Assetic/Asset/AssetCache.php
@@ -13,6 +13,7 @@ namespace Assetic\Asset;
 
 use Assetic\Cache\CacheInterface;
 use Assetic\Filter\FilterInterface;
+use Assetic\Filter\HashableInterface;
 
 /**
  * Caches an asset to avoid the cost of loading and dumping.
@@ -150,7 +151,12 @@ class AssetCache implements AssetInterface
         $cacheKey .= $asset->getLastModified();
 
         foreach ($asset->getFilters() as $filter) {
-            $cacheKey .= serialize($filter);
+            if ($filter instanceof HashableInterface) {
+                $cacheKey .= $filter->hash();
+            }
+            else {
+                $cacheKey .= serialize($filter);
+            }
         }
 
         if ($values = $asset->getValues()) {

--- a/src/Assetic/Filter/HashableInterface.php
+++ b/src/Assetic/Filter/HashableInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2011 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+
+/**
+ * A filter can implement a hash function
+ *
+ * @author Francisco Facioni <fran6co@gmail.com>
+ */
+interface HashableInterface
+{
+    /**
+     * Generates a hash for the object
+     *
+     * @return string Object hash
+     */
+    function hash();
+}


### PR DESCRIPTION
An example is Twig.js filter. Check this thread https://github.com/schmittjoh/twig.js/pull/28 for more information.
