### PR TITLE
Add setter-method for compass load paths

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -133,6 +133,11 @@ class CompassFilter implements FilterInterface
         $this->plugins[] = $plugin;
     }
 
+    public function setLoadPaths(array $loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+
     public function addLoadPath($loadPath)
     {
         $this->loadPaths[] = $loadPath;


### PR DESCRIPTION
Hi,

the CompassFilter already provides the method addLoadPath(). To be able to configure the load paths via symfonys di-container when using the AsseticBundle, an additional method setLoadPaths() would be nice.

```
<?xml version="1.0" ?>

<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">

    <parameters>
        <parameter key="assetic.filter.compass.class">Assetic\Filter\CompassFilter</parameter>
        ...
        <parameter key="assetic.filter.compass.http_javascripts_path">null</parameter>
        <parameter key="assetic.filter.compass.plugins" type="collection" />
        <parameter key="assetic.filter.compass.load_paths" type="collection" />
    </parameters>

    <services>
        <service id="assetic.filter.compass" class="%assetic.filter.compass.class%">
            <tag name="assetic.filter" alias="compass" />
            ...
            <call method="setHttpJavascriptsPath"><argument>%assetic.filter.compass.http_javascripts_path%</argument></call>
            <call method="setPlugins"><argument>%assetic.filter.compass.plugins%</argument></call>
            <call method="setLoadPaths"><argument>%assetic.filter.compass.load_paths%</argument></call>
        </service>
    </services>
</container>
```

In the end, the load paths would be configurable in symfonys config.yml:

```
assetic:
    debug:          %kernel.debug%
    use_controller: false
    bundles:
        - eFormFrontendBundle
    #java: /usr/bin/java
    filters:
        compass: 
            debug:  false
            bin: %compass_bin%
            load_paths: %additional_compass_paths%
```

Pretty much the same thing already exists for the compass plugins (setPlugins() and addPlugin()).. What do you think? Thx
