### PR TITLE
fixed compass and sass filters to work without an explicit passed-in rub...

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -178,12 +178,16 @@ class CompassFilter implements FilterInterface
         // compass does not seems to handle symlink, so we use realpath()
         $tempDir = realpath(sys_get_temp_dir());
 
-        $pb = new ProcessBuilder(array(
-            $this->rubyPath,
+        $compassProcessArgs = array(
             $this->compassPath,
             'compile',
             $tempDir,
-        ));
+        );
+        if (null !== $this->rubyPath) {
+            array_unshift($compassProcessArgs, $this->rubyPath);
+        }
+
+        $pb = new ProcessBuilder($compassProcessArgs);
         $pb->inheritEnvironmentVariables();
 
         if ($this->force) {

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -101,7 +101,12 @@ class SassFilter implements FilterInterface
 
     public function filterLoad(AssetInterface $asset)
     {
-        $pb = new ProcessBuilder(array($this->rubyPath, $this->sassPath));
+        $sassProcessArgs = array($this->sassPath);
+        if (null !== $this->rubyPath) {
+            array_unshift($sassProcessArgs, $this->rubyPath);
+        }
+
+        $pb = new ProcessBuilder($sassProcessArgs);
 
         $root = $asset->getSourceRoot();
         $path = $asset->getSourcePath();


### PR DESCRIPTION
...y path

Previous commit allowing a passed-in explicit ruby path for the Compass and Sass filters broke the case where an explicit ruby path is not passed in.  This commit allows both cases.
