### PR TITLE
Filter uglifycss

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
         <!-- <server name="TWIG_LIB" value="/path/to/twig/lib" /> -->
         <!-- <server name="YUI_COMPRESSOR_JAR" value="/path/to/yuicompressor-2.4.2.jar" /> -->
         <!-- <server name="UGLIFYJS_BIN" value="/path/to/uglifyjs" /> -->
+        <!-- <server name="UGLIFYCSS_BIN" value="/path/to/uglifycss" /> -->
         <!-- <server name="PACKER" value="/path/to/class.JavaScriptPacker.php" /> -->
     </php>
 

--- a/tests/Assetic/Test/Filter/UglifyCssFilterTest.php
+++ b/tests/Assetic/Test/Filter/UglifyCssFilterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2012 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Asset\FileAsset;
+use Assetic\Filter\UglifyCssFilter;
+
+/**
+ * @group integration
+ */
+class UglifyCssFilterTest extends \PHPUnit_Framework_TestCase
+{
+    private $asset;
+    private $filter;
+
+    protected function setUp()
+    {
+        if (!isset($_SERVER['UGLIFYCSS_BIN'])) {
+            $this->markTestSkipped('There is no uglifyCss configuration.');
+        }
+
+        $this->asset = new FileAsset(__DIR__.'/fixtures/uglifycss/main.css');
+        $this->asset->load();
+
+        if (isset($_SERVER['NODE_BIN'])) {
+            $this->filter = new UglifyCssFilter($_SERVER['UGLIFYCSS_BIN'], $_SERVER['NODE_BIN']);
+        } else {
+            $this->filter = new UglifyCssFilter($_SERVER['UGLIFYCSS_BIN']);
+        }
+    }
+
+    protected function tearDown()
+    {
+        $this->asset = null;
+        $this->filter = null;
+    }
+
+    public function testUglify()
+    {
+        $this->filter->filterDump($this->asset);
+
+        $expected = <<<CSS
+@import url("fonts.css");body{background:black}
+CSS;
+        $this->assertSame($expected, $this->asset->getContent());
+    }
+
+}

--- a/tests/Assetic/Test/Filter/fixtures/uglifycss/fonts.css
+++ b/tests/Assetic/Test/Filter/fixtures/uglifycss/fonts.css
@@ -1,0 +1,3 @@
+body {
+    color: white;
+}

--- a/tests/Assetic/Test/Filter/fixtures/uglifycss/main.css
+++ b/tests/Assetic/Test/Filter/fixtures/uglifycss/main.css
@@ -1,0 +1,9 @@
+/**
+ * Copyright
+ */
+
+@import url("fonts.css");
+
+body {
+    background: black;
+}


### PR DESCRIPTION
Just hated to require java only for yui. Now you can have a 100% clean JS solution with both uglify-js & uglify-css.
Uglify-css is not in the NPM repo for now. To setup (as sudo) :

```
wget https://github.com/fmarcia/UglifyCSS/zipball/master -O ~/uglify-css.zip; unzip ~/uglify-css.zip -d ~/uglify-css;npm install -g ~/uglify-css/*; rm -rf ~/uglify-css*
```
