### PR TITLE
Fixed fatal error when forgot to close stylesheets or javascripts block in Twig

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -119,9 +119,7 @@ class AsseticTokenParser extends \Twig_TokenParser
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        $endtag = 'end'.$this->getTag();
-        $test = function(\Twig_Token $token) use($endtag) { return $token->test($endtag); };
-        $body = $this->parser->subparse($test, true);
+        $body = $this->parser->subparse(array($this, 'testEndTag'), true);
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
@@ -141,6 +139,11 @@ class AsseticTokenParser extends \Twig_TokenParser
     public function getTag()
     {
         return $this->tag;
+    }
+
+    public function testEndTag(\Twig_Token $token)
+    {
+        return $token->test(array('end'.$this->getTag()));
     }
 
     protected function createNode(AssetInterface $asset, \Twig_NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)


### PR DESCRIPTION
Now it causes standard twig exception:

Unexpected tag name "endblock" (expecting closing tag for the "stylesheets" tag defined near line 35) in ::base.html.twig at line 35
