### PR TITLE
Added support for Google Closure language option

### DIFF
--- a/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
@@ -35,6 +35,11 @@ abstract class BaseCompilerFilter implements FilterInterface
     const LEVEL_DEFAULT = 'DEFAULT';
     const LEVEL_VERBOSE = 'VERBOSE';
 
+    // languages
+    const LANGUAGE_ECMASCRIPT3 = 'ECMASCRIPT3';
+    const LANGUAGE_ECMASCRIPT5 = 'ECMASCRIPT5';
+    const LANGUAGE_ECMASCRIPT5_STRICT = 'ECMASCRIPT5_STRICT';
+
     protected $compilationLevel;
     protected $jsExterns;
     protected $externsUrl;
@@ -42,6 +47,7 @@ abstract class BaseCompilerFilter implements FilterInterface
     protected $formatting;
     protected $useClosureLibrary;
     protected $warningLevel;
+    protected $language;
 
     public function setCompilationLevel($compilationLevel)
     {
@@ -76,6 +82,11 @@ abstract class BaseCompilerFilter implements FilterInterface
     public function setWarningLevel($warningLevel)
     {
         $this->warningLevel = $warningLevel;
+    }
+
+    public function setLanguage($language)
+    {
+        $this->language = $language;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -57,6 +57,10 @@ class CompilerApiFilter extends BaseCompilerFilter
             $query['warning_level'] = $this->warningLevel;
         }
 
+        if (null !== $this->language) {
+            $query['language'] = $this->language;
+        }
+
         if (preg_match('/1|yes|on|true/i', ini_get('allow_url_fopen'))) {
             $context = stream_context_create(array('http' => array(
                 'method'  => 'POST',

--- a/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
@@ -74,6 +74,10 @@ class CompilerJarFilter extends BaseCompilerFilter
             $pb->add('--warning_level')->add($this->warningLevel);
         }
 
+        if (null !== $this->language) {
+            $pb->add('--language_in')->add($this->language);
+        }
+
         $pb->add('--js')->add($cleanup[] = $input = tempnam(sys_get_temp_dir(), 'assetic_google_closure_compiler'));
         file_put_contents($input, $asset->getContent());
 

--- a/tests/Assetic/Test/Filter/GoogleClosure/CompilerApiFilterTest.php
+++ b/tests/Assetic/Test/Filter/GoogleClosure/CompilerApiFilterTest.php
@@ -55,5 +55,30 @@ EOF;
         $filter->filterDump($asset);
 
         $this->assertEquals($expected, $asset->getContent());
+
+
+        $input = <<<EOF
+(function() {
+    var int = 123;
+    console.log(int);
+})();
+EOF;
+
+        $expected = <<<EOF
+(function() {
+  console.log(123)
+})();
+
+EOF;
+
+        $asset = new StringAsset($input);
+        $asset->load();
+
+        $filter->setLanguage(CompilerApiFilter::LANGUAGE_ECMASCRIPT5);
+
+        $filter->filterLoad($asset);
+        $filter->filterDump($asset);
+
+        $this->assertEquals($expected, $asset->getContent());
     }
 }

--- a/tests/Assetic/Test/Filter/GoogleClosure/CompilerJarFilterTest.php
+++ b/tests/Assetic/Test/Filter/GoogleClosure/CompilerJarFilterTest.php
@@ -49,5 +49,28 @@ EOF;
         $filter->filterDump($asset);
 
         $this->assertEquals($expected, $asset->getContent());
+
+
+        $input = <<<EOF
+(function() {
+    var int = 123;
+    console.log(int);
+})();
+EOF;
+
+        $expected = <<<EOF
+(function(){console.log(123)})();
+
+EOF;
+
+        $asset = new StringAsset($input);
+        $asset->load();
+
+        $filter->setLanguage(CompilerJarFilter::LANGUAGE_ECMASCRIPT5);
+
+        $filter->filterLoad($asset);
+        $filter->filterDump($asset);
+
+        $this->assertEquals($expected, $asset->getContent());
     }
 }


### PR DESCRIPTION
Added support for specifying the input language of the Closure filter because some JavaScript libraries, such as Ember.js, use words that are reserved in ES3 and need to be compiled as ES5.

Usage example:

``` php
<?php

use Assetic\Filter\GoogleClosure\CompilerApiFilter;

$filter = new CompilerApiFilter();
$filter->setLanguage(CompilerApiFilter::LANGUAGE_ECMASCRIPT5);
```

Both `CompilerApiFilter` and `CompilerJarFilter` support the language option.

Tests included.
