### PR TITLE
Partials should be included without the underscore

### DIFF
--- a/tests/Assetic/Test/Filter/fixtures/sass/main.scss
+++ b/tests/Assetic/Test/Filter/fixtures/sass/main.scss
@@ -1,3 +1,3 @@
-@import "_include";
+@import "include";
 
 .foo { color: red; }


### PR DESCRIPTION
Partials should be included without the underscore:
http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#partials
