### PR TITLE
1.0.x [Filters] Fixed issue with Yui process timing out by providing a setTimeout function

### DIFF
--- a/src/Assetic/Util/ProcessBuilder.php
+++ b/src/Assetic/Util/ProcessBuilder.php
@@ -22,7 +22,7 @@ class ProcessBuilder
     private $cwd;
     private $env;
     private $stdin;
-    private $timeout = 60;
+    private $timeout = 120;
     private $options = array();
     private $inheritEnv = false;
 


### PR DESCRIPTION
Hi,

There has been some discussion over an issue where filter processes such as yui_css are timing out on slower platforms such as Amazon micro instances, because the timeout is hardcoded as 60 seconds. 

https://github.com/kriswallsmith/assetic/issues/250

This change provides a means to set the timeout for yui_css and yui_js (and can be applied to any ProcessBuilder based filter), and there is a follow-up pull request to the AsseticBundle to allow this to be set within the config of assetic (I'll carry this out after this one).

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: N/A
License of the code: Any - free to include under current license
Documentation PR: https://github.com/kriswallsmith/assetic/issues/250

Cheers
Steve
