### PR TITLE
[Filters] Increase the process timeout from 60 secs to 120 secs so yui_css/js succeed

### DIFF
--- a/src/Assetic/Util/ProcessBuilder.php
+++ b/src/Assetic/Util/ProcessBuilder.php
@@ -22,7 +22,7 @@ class ProcessBuilder
     private $cwd;
     private $env;
     private $stdin;
-    private $timeout = 120;
+    private $timeout = 180;
     private $options = array();
     private $inheritEnv = false;
 


### PR DESCRIPTION
Hi,

There has an issue encountered where filter processes such as yui_css are timing out on slower platforms such as Amazon micro instances (https://github.com/kriswallsmith/assetic/issues/250), because the timeout is hardcoded as 60 seconds.

There is a stategic fix submitted under pull request https://github.com/kriswallsmith/assetic/pull/277, but this is a bugfix to increase the timeout so that the filter processes don't fail on slower platforms. Increasing the timeout to 120 seconds should allow slower machines to succeed when running filter operations.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets:
Todo: N/A
License of the code: Any - free to include under current license
Documentation PR: https://github.com/kriswallsmith/assetic/issues/250

Cheers
Steve
