### PR TITLE
 Avoid throwing exception when parsing a subdirectory of the current examined folder

### DIFF
--- a/src/Assetic/Asset/FileAsset.php
+++ b/src/Assetic/Asset/FileAsset.php
@@ -59,6 +59,8 @@ class FileAsset extends BaseAsset
             $this->getValues());
 
         if (!is_file($source)) {
+            if (is_dir($source)) return;
+
             throw new \RuntimeException(sprintf('The source file "%s" does not exist.', $source));
         }
 
@@ -71,6 +73,8 @@ class FileAsset extends BaseAsset
             $this->getValues());
 
         if (!is_file($source)) {
+            if (is_dir($source)) return;
+
             throw new \RuntimeException(sprintf('The source file "%s" does not exist.', $source));
         }
         return filemtime($source);


### PR DESCRIPTION
Having a folder structured as follows:

\MyBundle\Resources\public\css
css
  images
    image1.jpg
  file.css
  file1.css

declaring assets in twig file as follows

{% stylesheets 'bundle\mybundle\css*' ...

A RuntimeException is thrown when the css/images is parsed during assetic:dump
