### PR TITLE
Rewrite the regex named group using the old form

### DIFF
--- a/src/Assetic/Filter/BaseCssFilter.php
+++ b/src/Assetic/Filter/BaseCssFilter.php
@@ -46,7 +46,7 @@ abstract class BaseCssFilter implements FilterInterface
      */
     protected function filterUrls($content, $callback, $limit = -1, & $count = 0)
     {
-        return preg_replace_callback('/url\((["\']?)(?<url>.*?)(\\1)\)/', $callback, $content, $limit, $count);
+        return preg_replace_callback('/url\((["\']?)(?P<url>.*?)(\\1)\)/', $callback, $content, $limit, $count);
     }
 
     /**
@@ -63,8 +63,8 @@ abstract class BaseCssFilter implements FilterInterface
     protected function filterImports($content, $callback, $limit = -1, & $count = 0, $includeUrl = true)
     {
         $pattern = $includeUrl
-            ? '/@import (?:url\()?(\'|"|)(?<url>[^\'"\)\n\r]*)\1\)?;?/'
-            : '/@import (?!url\()(\'|"|)(?<url>[^\'"\)\n\r]*)\1;?/';
+            ? '/@import (?:url\()?(\'|"|)(?P<url>[^\'"\)\n\r]*)\1\)?;?/'
+            : '/@import (?!url\()(\'|"|)(?P<url>[^\'"\)\n\r]*)\1;?/';
 
         return preg_replace_callback($pattern, $callback, $content, $limit, $count);
     }


### PR DESCRIPTION
PHP 5.2.2 introduced named groups defined as (?<name>...) or (?'name'...) like
what it is used in the Assetic\Filter\BaseCssFilter. Through my research, I
found that this was enabled by the version 7 of PCRE (see
http://www.pcre.org/changelog.txt version 7.0 line 34). You can see what PCRE
version is used in each version of PHP here :
http://www.php.net/manual/fr/pcre.installation.php

For a reason I do not fully understand, PHP in CentOS 5.8 was compiled with
version 6.6 of PCRE that do not support that new way of defining named groups.
You can know which version of PCRE PHP is using  by executing that line :

```
php -r 'echo PCRE_VERSION;'
```

So to fix that problem, I modified the code to use the old way of defining
named group, using the uppercase P.
