### PR TITLE
fix two bugs in CssRewriteFilter and AssetCollection

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -133,7 +133,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     {
         // loop through leaves and dump each asset
         $parts = array();
-        foreach ($this as $asset) {
+        foreach ($this->assets as $asset) {
             $parts[] = $asset->dump($additionalFilter);
         }
 

--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -81,6 +81,10 @@ class CssRewriteFilter extends BaseCssFilter
 
             // document relative
             $url = $matches['url'];
+            if (0 === strpos($url, '../')){
+                $url = substr($url, 3);
+            }
+
             while (0 === strpos($url, '../') && 2 <= substr_count($path, '/')) {
                 $path = substr($path, 0, strrpos(rtrim($path, '/'), '/') + 1);
                 $url = substr($url, 3);


### PR DESCRIPTION
For CssRewriteFilter:

For example:
If you have a css in /assets/admin/css/boostrapt.css and the url for the image resources is ../img/image.jpg

The CssRewriteFilter define the url like /assets/img/image.jpg but is incorrect because the first ".." in the image resource is for get out of the css file.

For AssetCollection:

when you are creating an AssetCollection with many files...for example..

$css_collection = new AssetCollection(array(
new FileAsset('file1.css'),
new FileAsset('file2.css'),
new FileAsset('file3.css')
));

and then you try to print with $css_collection->dump(); the only file printed is the first because is wrong the iteration that I explain before.
