### PR TITLE
Set conditionally env to HOME

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -50,7 +50,7 @@ class CompassFilter implements FilterInterface
     private $httpImagesPath;
     private $generatedImagesPath;
     private $httpJavascriptsPath;
-    private $homeEnv;
+    private $homeEnv = true;
 
     public function __construct($compassPath = '/usr/bin/compass', $rubyPath = null)
     {


### PR DESCRIPTION
The HOME setEnv creates problems (cannot find rubyGems for instance) when it is used with bundler, so this option makes it optional, since it is refered as not really useful.
