### PR TITLE
Added http_generated_images_path configuration option for the Compass filter

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -48,6 +48,7 @@ class CompassFilter implements FilterInterface
     private $loadPaths = array();
     private $httpPath;
     private $httpImagesPath;
+    private $httpGeneratedImagesPath;
     private $generatedImagesPath;
     private $httpJavascriptsPath;
     private $homeEnv = true;
@@ -156,6 +157,11 @@ class CompassFilter implements FilterInterface
         $this->httpImagesPath = $httpImagesPath;
     }
 
+    public function setHttpGeneratedImagesPath($httpGeneratedImagesPath)
+    {
+        $this->httpGeneratedImagesPath = $httpGeneratedImagesPath;
+    }
+
     public function setGeneratedImagesPath($generatedImagesPath)
     {
         $this->generatedImagesPath = $generatedImagesPath;
@@ -256,6 +262,10 @@ class CompassFilter implements FilterInterface
 
         if ($this->httpImagesPath) {
             $optionsConfig['http_images_path'] = $this->httpImagesPath;
+        }
+
+        if ($this->httpGeneratedImagesPath) {
+            $optionsConfig['http_generated_images_path'] = $this->httpGeneratedImagesPath;
         }
 
         if ($this->generatedImagesPath) {


### PR DESCRIPTION
Depending on your project configuration, having an option to set `http_images_path` but not `http_generated_images_path` could break your sprites path.

I've also noticed that not all Compass options [1] are supported by the filter, as well. I could add support for the relevant ones in PHP land in another PR if you want.

[1] http://compass-style.org/help/tutorials/configuration-reference/ - In the Configuration Properties section.
