### PR TITLE
Fix functions.php that failed when required multiple times

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "autoload": {
         "psr-0": { "Assetic": "src/" },
-        "files": ["src/functions.php"]
+        "files": ["src/required.php"]
     },
     "extra": {
         "branch-alias": {

--- a/src/required.php
+++ b/src/required.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__.'/functions.php';


### PR DESCRIPTION
Fixes the following that occured when using behat + symfony2 extension + a symfony2 app using assetic

```
PHP Fatal error:  Cannot redeclare assetic_init() (previously declared in vendor/kriswallsmith/assetic/src/functions.php:20) in /vendor/kriswallsmith/assetic/src/functions.php on line 26

Fatal error: Cannot redeclare assetic_init() (previously declared in /vendor/kriswallsmith/assetic/src/functions.php:20) in /vendor/kriswallsmith/assetic/src/functions.php on line 26
```

Swiftmailer uses the same trick : https://github.com/swiftmailer/swiftmailer/blob/master/lib/swift_required.php
