### PR TITLE
Replace Still Maintained status with Travis-CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Assetic ![project status](http://stillmaintained.com/kriswallsmith/assetic.png) #
+# Assetic [![Build Status](https://secure.travis-ci.org/kriswallsmith/assetic.png)](http://travis-ci.org/kriswallsmith/assetic) #
 
 Assetic is an asset management framework for PHP.
 


### PR DESCRIPTION
http://stillmaintained.com/ shut down August 1, 2012.
