### PR TITLE
Add a non-persistant asset cache

### DIFF
--- a/src/Assetic/Cache/ArrayCache.php
+++ b/src/Assetic/Cache/ArrayCache.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2012 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Cache;
+
+/**
+ * A simple array cache
+ *
+ * @author Michael Mifsud <xzyfer@gmail.com>
+ */
+class ArrayCache implements CacheInterface
+{
+    private $cache = array();
+
+    /**
+     * @see CacheInterface::has()
+     */
+    public function has($key)
+    {
+        return isset($this->cache[$key]);
+    }
+
+    /**
+     * @see CacheInterface::get()
+     */
+    public function get($key)
+    {
+        if(!$this->has($key)) {
+            throw new \RuntimeException('There is no cached value for '.$key);
+        }
+
+        return $this->cache[$key];
+    }
+
+    /**
+     * @see CacheInterface::set()
+     */
+    public function set($key, $value)
+    {
+        $this->cache[$key] = $value;
+    }
+
+    /**
+     * @see CacheInterface::remove()
+     */
+    public function remove($key)
+    {
+        unset($this->cache[$key]);
+    }
+}

--- a/tests/Assetic/Test/Cache/ArrayCacheTest.php
+++ b/tests/Assetic/Test/Cache/ArrayCacheTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2012 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Cache;
+
+use Assetic\Cache\ArrayCache;
+
+/**
+ * @group integration
+ */
+class ArrayCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCache()
+    {
+        $cache = new ArrayCache();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $cache->set('foo', 'bar');
+        $this->assertEquals('bar', $cache->get('foo'));
+
+        $this->assertTrue($cache->has('foo'));
+
+        $cache->remove('foo');
+        $this->assertFalse($cache->has('foo'));
+    }
+}


### PR DESCRIPTION
This pull request adds a non-persistent asset cache backed by php arrays.
### why?

There are times when you don't want to persist a cache. When a function is expected to return cache object but you don't want the cache to be persisted, you don't want to have to type check the returned object.
### use case?

We use this in AsseticBundle when working with Zurb's Foundation and Twitter's Bootstrap. We need this because the default filesystem cache relies on a file's last modified time. We using sass you'll often have an `app.scss` that just includes other sass files. You would then only link the `app.scss` in your document through assetic. This causes the filesystem cache to never bust because the `app.scss` file itself never changes.
