### PR TITLE
Modify regex in filterIEFilters()

### DIFF
--- a/src/Assetic/Filter/BaseCssFilter.php
+++ b/src/Assetic/Filter/BaseCssFilter.php
@@ -84,6 +84,6 @@ abstract class BaseCssFilter implements FilterInterface
      */
     protected function filterIEFilters($content, $callback, $limit = -1, &$count = 0)
     {
-        return preg_replace_callback('/src=(["\']?)(?<url>.*?)\\1/', $callback, $content, $limit, $count);
+        return preg_replace_callback('/src=(["\']?)(?P<url>.*?)\\1/', $callback, $content, $limit, $count);
     }
 }


### PR DESCRIPTION
Changed (?<url>) in regex to (?P<url>) because the short version is not supported in PCRE lower than 7.0 such as in CentOS 5.8.
