### PR TITLE
Added possibility to add multiple scss&sass load paths at once.

### DIFF
--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -79,6 +79,11 @@ class SassFilter implements FilterInterface
         $this->lineNumbers = $lineNumbers;
     }
 
+    public function setLoadPaths(array $loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+    
     public function addLoadPath($loadPath)
     {
         $this->loadPaths[] = $loadPath;


### PR DESCRIPTION
This was already possible in the compass filter so something like that works in Symfony2. 
- https://gist.github.com/3964620
- https://github.com/symfony/AsseticBundle/blob/master/Resources/config/filters/compass.xml

For a similiar call we need a similiar possibilty to add multiple import paths at once.
