### PR TITLE
Removes the parent cache busting hash, we want to invalidate only if the actual asset changed not if one of the siblings did

### DIFF
--- a/src/Assetic/Factory/Worker/CacheBustingWorker.php
+++ b/src/Assetic/Factory/Worker/CacheBustingWorker.php
@@ -61,6 +61,9 @@ class CacheBustingWorker implements WorkerInterface
             return;
         }
 
+        // Remove parent cache busting hash, only one is needed
+        $url = preg_replace('/^([^-|_]+)-[^_]+_/', '${1}_', $url);
+
         $asset->setTargetPath(substr($url, 0, (strlen($oldExt) + 1) * -1).$newExt);
     }
 


### PR DESCRIPTION
This fixes a bug reported by @acasademont in https://github.com/symfony/AsseticBundle/pull/119. Working on dev the container cache busting hash gets propagated to it children.
