### PR TITLE
Made the initialization of variable values lazy

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticExtension.php
+++ b/src/Assetic/Extension/Twig/AsseticExtension.php
@@ -59,7 +59,7 @@ class AsseticExtension extends \Twig_Extension
         return array(
             'assetic' => array(
                 'debug' => $this->factory->isDebug(),
-                'vars'  => null !== $this->valueSupplier ? $this->valueSupplier->getValues() : array(),
+                'vars'  => null !== $this->valueSupplier ? new ValueContainer($this->valueSupplier) : array(),
             ),
         );
     }

--- a/src/Assetic/Extension/Twig/ValueContainer.php
+++ b/src/Assetic/Extension/Twig/ValueContainer.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2012 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Extension\Twig;
+
+use Assetic\ValueSupplierInterface;
+
+/**
+ * Container for values initialized lazily from a ValueSupplierInterface.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ValueContainer implements \ArrayAccess, \IteratorAggregate, \Countable
+{
+    private $values;
+    private $valueSupplier;
+
+    public function __construct(ValueSupplierInterface $valueSupplier)
+    {
+        $this->valueSupplier = $valueSupplier;
+    }
+
+    public function offsetExists($offset)
+    {
+        $this->initialize();
+
+        return array_key_exists($offset, $this->values);
+    }
+
+    public function offsetGet($offset)
+    {
+        $this->initialize();
+
+        if (!array_key_exists($offset, $this->values)) {
+            throw new \OutOfRangeException(sprintf('The variable "%s" does not exist.', $offset));
+        }
+
+        return $this->values[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \BadMethodCallException('The ValueContainer is read-only.');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \BadMethodCallException('The ValueContainer is read-only.');
+    }
+
+    public function getIterator()
+    {
+        $this->initialize();
+
+        return new \ArrayIterator($this->values);
+    }
+
+    public function count()
+    {
+        $this->initialize();
+
+        return count($this->values);
+    }
+
+    private function initialize()
+    {
+        if (null === $this->values) {
+            $this->values = $this->valueSupplier->getValues();
+        }
+    }
+}

--- a/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
+++ b/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
@@ -211,9 +211,6 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('getValues')
             ->will($this->returnValue(array('foo' => 'a', 'bar' => 'b')));
 
-        // Add the extension again (replacing the previous one) with a value supplier mock with the expectations
-        $this->twig->addExtension(new AsseticExtension($this->factory, array(), $this->valueSupplier));
-
         $xml = $this->renderXml('variables.twig');
         $this->assertEquals(2, $xml->url->count());
         $this->assertEquals("js/7d0828c_foo_1.a.b.js", (string) $xml->url[0]);


### PR DESCRIPTION
This avoids calling the supplier if you don't have any asset using
variables.

It also fixes symfony/AsseticBundle#138 as the supplier is not called
anymore as soon as the Twig globals are read from the extension.
