### PR TITLE
Convert all private members on Assetic\Asset\* classes to protected.

### DIFF
--- a/src/Assetic/Asset/AssetCache.php
+++ b/src/Assetic/Asset/AssetCache.php
@@ -22,8 +22,8 @@ use Assetic\Filter\HashableInterface;
  */
 class AssetCache implements AssetInterface
 {
-    private $asset;
-    private $cache;
+    protected $asset;
+    protected $cache;
 
     public function __construct(AssetInterface $asset, CacheInterface $cache)
     {

--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -23,14 +23,14 @@ use Assetic\Filter\FilterInterface;
  */
 class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
 {
-    private $assets;
-    private $filters;
-    private $sourceRoot;
-    private $targetPath;
-    private $content;
-    private $clones;
-    private $vars;
-    private $values;
+    protected $assets;
+    protected $filters;
+    protected $sourceRoot;
+    protected $targetPath;
+    protected $content;
+    protected $clones;
+    protected $vars;
+    protected $values;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -21,9 +21,9 @@ use Assetic\Filter\FilterInterface;
  */
 class AssetReference implements AssetInterface
 {
-    private $am;
-    private $name;
-    private $filters = array();
+    protected $am;
+    protected $name;
+    protected $filters = array();
 
     public function __construct(AssetManager $am, $name)
     {
@@ -113,7 +113,7 @@ class AssetReference implements AssetInterface
         $this->callAsset(__FUNCTION__, array($values));
     }
 
-    // private
+    // protected
 
     private function callAsset($method, $arguments = array())
     {

--- a/src/Assetic/Asset/BaseAsset.php
+++ b/src/Assetic/Asset/BaseAsset.php
@@ -24,14 +24,14 @@ use Assetic\Filter\FilterInterface;
  */
 abstract class BaseAsset implements AssetInterface
 {
-    private $filters;
-    private $sourceRoot;
-    private $sourcePath;
-    private $targetPath;
-    private $content;
-    private $loaded;
-    private $vars;
-    private $values;
+    protected $filters;
+    protected $sourceRoot;
+    protected $sourcePath;
+    protected $targetPath;
+    protected $content;
+    protected $loaded;
+    protected $vars;
+    protected $values;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/FileAsset.php
+++ b/src/Assetic/Asset/FileAsset.php
@@ -21,7 +21,7 @@ use Assetic\Filter\FilterInterface;
  */
 class FileAsset extends BaseAsset
 {
-    private $source;
+    protected $source;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/GlobAsset.php
+++ b/src/Assetic/Asset/GlobAsset.php
@@ -22,8 +22,8 @@ use Assetic\Filter\FilterInterface;
  */
 class GlobAsset extends AssetCollection
 {
-    private $globs;
-    private $initialized;
+    protected $globs;
+    protected $initialized;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -22,8 +22,8 @@ use Assetic\Filter\FilterInterface;
  */
 class HttpAsset extends BaseAsset
 {
-    private $sourceUrl;
-    private $ignoreErrors;
+    protected $sourceUrl;
+    protected $ignoreErrors;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/Iterator/AssetCollectionFilterIterator.php
+++ b/src/Assetic/Asset/Iterator/AssetCollectionFilterIterator.php
@@ -21,8 +21,8 @@ namespace Assetic\Asset\Iterator;
  */
 class AssetCollectionFilterIterator extends \RecursiveFilterIterator
 {
-    private $visited;
-    private $sources;
+    protected $visited;
+    protected $sources;
 
     /**
      * Constructor.

--- a/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
+++ b/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
@@ -23,10 +23,10 @@ use Assetic\Asset\AssetCollectionInterface;
  */
 class AssetCollectionIterator implements \RecursiveIterator
 {
-    private $assets;
-    private $filters;
-    private $output;
-    private $clones;
+    protected $assets;
+    protected $filters;
+    protected $output;
+    protected $clones;
 
     public function __construct(AssetCollectionInterface $coll, \SplObjectStorage $clones)
     {

--- a/src/Assetic/Asset/StringAsset.php
+++ b/src/Assetic/Asset/StringAsset.php
@@ -20,8 +20,8 @@ use Assetic\Filter\FilterInterface;
  */
 class StringAsset extends BaseAsset
 {
-    private $content;
-    private $lastModified;
+    protected $content;
+    protected $lastModified;
 
     /**
      * Constructor.


### PR DESCRIPTION
i'm making this request as part of the overall attempt to shift Drupal to using Assetic. see https://drupal.org/node/1871596, but especially https://drupal.org/node/1871596#comment-6884638 .

we have to subclass Assetic's assets classes in order to accommodate some additional metadata layers (we have to deal with asset reordering in a way that Assetic does not appear to be built for). so it's really quite important that we be able to mutate, or at _least_ access, these various properties. BaseAsset provides getters for most of the properties, but HttpAsset, for example, provides no getter for $sourceUrl. even with getters for everything, though, the code would be awkward and verbose to do all such assignments/accessings via methods.

the alternative is simply writing our own BaseAsset class, which would be pretty awful - i'd like us to keep things DRY.

i certainly understand not wanting the properties public, but i don't see any obvious reason to not make them protected. i haven't spent a TON of time looking at the AssetInterface family tree to figure out any implicit contracts there, but nothing has jumped out at me so far that really necessitates restricting access to those members by subclasses.

i realize there's a somewhat similar issue over at #236, but that deals with members on the writer classes, on which @schmittjoh's comments about the use of composition seem more applicable. in this case, i'd prefer to avoid composition because it would make serialization (something else we'll likely need to do) more complex, make the class structure itself more complex in general, and all without a use case for utilizing the swappability composition brings.
