### PR TITLE
Compass additional_import_directory now uses absolute path to the asset's folder

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -194,7 +194,7 @@ class CompassFilter extends BaseProcessFilter
 
         $loadPaths = $this->loadPaths;
         if ($root && $path) {
-            $loadPaths[] = dirname($root.'/'.$path);
+            $loadPaths[] = realpath(dirname($root.'/'.$path));
         }
 
         // compass does not seems to handle symlink, so we use realpath()


### PR DESCRIPTION
My @imports weren't working, it looks like assetic was copying files to the system temp directory, then trying to @import files relative to that (looking in /tmp/css/sass). 

This change sets it to use the absolute path to the sass directory, thus looking in, for example /var/www/css/sass.

Hope that makes sense :)
