### PR TITLE
Support for setting Java stack size for yui_css compressor

### DIFF
--- a/src/Assetic/Filter/Yui/BaseCompressorFilter.php
+++ b/src/Assetic/Filter/Yui/BaseCompressorFilter.php
@@ -68,7 +68,7 @@ abstract class BaseCompressorFilter extends BaseProcessFilter
         $command = array($this->javaPath);
 
         if (null !== $this->stackSize) {
-	    $command[] = '-Xss'.$this->stackSize;
+            $command[] = '-Xss'.$this->stackSize;
         }		
 
         $command[] = '-jar';


### PR DESCRIPTION
With some css files, yuicompressor generates a stack overflow exception.
Here I add an option for setting java stack size
