### PR TITLE
GlobAsset passing vars to FileAsset bugfix

### DIFF
--- a/src/Assetic/Asset/GlobAsset.php
+++ b/src/Assetic/Asset/GlobAsset.php
@@ -103,7 +103,7 @@ class GlobAsset extends AssetCollection
             if (false !== $paths = glob($glob)) {
                 foreach ($paths as $path) {
                     if (is_file($path)) {
-                        $this->add(new FileAsset($path, array(), $this->getSourceRoot()));
+                        $this->add(new FileAsset($path, array(), $this->getSourceRoot(), $this->getSourcePath(), $this->getVars()));
                     }
                 }
             }


### PR DESCRIPTION
This fixes a bug when using GlobAssets with variables (locale variable for example). The fix propagates variables to the respective FileAsset.
