### PR TITLE
Update Symfony deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.1",
-        "symfony/process": ">=2.1.0,<2.3-dev"
+        "symfony/process": "~2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
This should be safe and would allow to not use a new branch for Symfony 2.3.
