### PR TITLE
LessphpFilter: Add setLoadPaths method

### DIFF
--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -51,11 +51,9 @@ class LessphpFilter implements FilterInterface
      *
      * @param array $loadPaths Load paths
      */
-    public function setLoadPaths($loadPaths = array())
+    public function setLoadPaths(array $loadPaths)
     {
         $this->loadPaths = $loadPaths;
-
-        return $this;
     }
 
     public function setPresets(array $presets)


### PR DESCRIPTION
Allows setting all load paths to be used by lessphp. Goes hand in hand with https://github.com/symfony/AsseticBundle/pull/179
