### PR TITLE
Made it compatible with apc 3.0.0

### DIFF
--- a/src/Assetic/Cache/ApcCache.php
+++ b/src/Assetic/Cache/ApcCache.php
@@ -25,6 +25,13 @@ class ApcCache implements CacheInterface
      */
     public function has($key)
     {
+        if (!function_exists('apc_exists')) {
+            $result = false;
+            apc_fetch($key, $result);
+
+            return $result;
+        }
+
         return apc_exists($key);
     }
 


### PR DESCRIPTION
This is a BC fix for APC < 3.1.4 (apc_exists was introduced in that version). A similar and smaller fix might be 

``` php
return (bool)apc_fetch($key);
```

But here there's a chance of a misbehaviour in case of you store a boolean inside APC.
