### PR TITLE
Add cjsDelivery (CommonJS compiler) filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "cssmin/cssmin": "*",
         "mrclay/minify": "*",
         "kamicane/packager": "*",
-        "joliclic/javascript-packer": "*"
+        "joliclic/javascript-packer": "*",
+        "mattcg/cjsdelivery": "*"
     },
     "minimum-stability": "dev",
     "suggest": {
@@ -36,7 +37,8 @@
         "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
         "leafo/scssphp": "Assetic provides the integration with the scssphp SCSS compiler",
         "ptachoire/cssembed": "Assetic provides the integration with phpcssembed to embed data uris",
-        "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin"
+        "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin",
+        "mattcg/cjsdelivery": "Assetic provides the integration with the cjsDelivery CommonJS compiler"
     },
     "autoload": {
         "psr-0": { "Assetic": "src/" },

--- a/src/Assetic/Filter/CjsDeliveryFilter.php
+++ b/src/Assetic/Filter/CjsDeliveryFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+
+use MattCG\cjsDelivery\DeliveryFactory;
+
+/**
+ * Loads JavaScript files using cjsDelivery.
+ *
+ * @link https://github.com/mattcg/cjsDelivery
+ *
+ * @author Matthew Caruana Galizia <m@m.cg>
+ */
+class CjsDeliveryFilter implements FilterInterface
+{
+    const EXT_JS = 'js';
+
+    private $minifyidentifiers = false;
+    private $includes = null;
+    private $parsepragmas = false;
+    private $pragmaformat = null;
+    private $pragmas = null;
+
+    private function stripExtension($filepath)
+    {
+        return preg_replace('/\.' . self::EXT_JS . '$/', '', $filepath);
+    }
+
+    public function setMinifyIdentifiers($minifyidentifiers)
+    {
+        $this->minifyidentifiers = $minifyidentifiers;
+    }
+
+    public function setIncludes($includes)
+    {
+        $this->includes = $includes;
+    }
+
+    public function setPragmaFormat($pragmaformat)
+    {
+        $this->pragmaformat = $pragmaformat;
+    }
+
+    public function setParsePragmas($parsepragmas)
+    {
+        $this->parsepragmas = $parsepragmas;
+    }
+
+    public function setPragmas($pragmas)
+    {
+        $this->pragmas = $pragmas;
+    }
+
+    public function filterLoad(AssetInterface $asset) {
+        $filepath = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
+        $moduleidentifier = $this->stripExtension($filepath);
+
+        $options = array();
+        $options['includes'] = $this->includes;
+        $options['minifyIdentifiers'] = $this->minifyidentifiers;
+        $options['parsePragmas'] = $this->parsepragmas;
+        $options['pragmas'] = $this->pragmas;
+        $options['pragmaFormat'] = $this->pragmaformat;
+
+        $delivery = DeliveryFactory::create($options);
+        $delivery->addModule($moduleidentifier, $asset->getContent());
+        $delivery->setMainModule($moduleidentifier);
+
+        $content = $delivery->getOutput();
+        $asset->setContent($content);
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+    }
+}

--- a/src/Assetic/Filter/CjsDeliveryFilter.php
+++ b/src/Assetic/Filter/CjsDeliveryFilter.php
@@ -24,22 +24,16 @@ use MattCG\cjsDelivery\DeliveryFactory;
  */
 class CjsDeliveryFilter implements FilterInterface
 {
-    const EXT_JS = 'js';
 
-    private $minifyidentifiers = false;
-    private $includes = null;
-    private $parsepragmas = false;
-    private $pragmaformat = null;
-    private $pragmas = null;
+    private $minifyIdentifiers = false;
+    private $includes;
+    private $parsePragmas = false;
+    private $pragmaFormat;
+    private $pragmas = array();
 
-    private function stripExtension($filepath)
+    public function setMinifyIdentifiers($minifyIdentifiers)
     {
-        return preg_replace('/\.' . self::EXT_JS . '$/', '', $filepath);
-    }
-
-    public function setMinifyIdentifiers($minifyidentifiers)
-    {
-        $this->minifyidentifiers = $minifyidentifiers;
+        $this->minifyIdentifiers = $minifyIdentifiers;
     }
 
     public function setIncludes($includes)
@@ -47,14 +41,14 @@ class CjsDeliveryFilter implements FilterInterface
         $this->includes = $includes;
     }
 
-    public function setPragmaFormat($pragmaformat)
+    public function setPragmaFormat($pragmaFormat)
     {
-        $this->pragmaformat = $pragmaformat;
+        $this->pragmaFormat = $pragmaFormat;
     }
 
-    public function setParsePragmas($parsepragmas)
+    public function setParsePragmas($parsePragmas)
     {
-        $this->parsepragmas = $parsepragmas;
+        $this->parsePragmas = $parsePragmas;
     }
 
     public function setPragmas($pragmas)
@@ -68,10 +62,10 @@ class CjsDeliveryFilter implements FilterInterface
 
         $options = array();
         $options['includes'] = $this->includes;
-        $options['minifyIdentifiers'] = $this->minifyidentifiers;
-        $options['parsePragmas'] = $this->parsepragmas;
+        $options['minifyIdentifiers'] = $this->minifyIdentifiers;
+        $options['parsePragmas'] = $this->parsePragmas;
         $options['pragmas'] = $this->pragmas;
-        $options['pragmaFormat'] = $this->pragmaformat;
+        $options['pragmaFormat'] = $this->pragmaFormat;
 
         $delivery = DeliveryFactory::create($options);
         $delivery->addModule($moduleidentifier, $asset->getContent());
@@ -83,5 +77,10 @@ class CjsDeliveryFilter implements FilterInterface
 
     public function filterDump(AssetInterface $asset)
     {
+    }
+
+    private function stripExtension($filepath)
+    {
+        return preg_replace('/\.js$/', '', $filepath);
     }
 }

--- a/tests/Assetic/Test/Filter/CjsDeliveryFilterTest.php
+++ b/tests/Assetic/Test/Filter/CjsDeliveryFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Asset\FileAsset;
+use Assetic\Asset\StringAsset;
+use Assetic\Filter\CjsDeliveryFilter;
+
+/**
+ * @group integration
+ */
+class CjsDeliveryFilterTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('\\MattCG\\cjsDelivery\\DeliveryFactory')) {
+            $this->markTestSkipped('cjsDelivery is not installed');
+        }
+    }
+
+    public function testSingleModuleCompile()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/commonjs/lib/novendordeps.js');
+        $asset->load();
+
+        $this->getFilter()->filterLoad($asset);
+
+        $this->assertGreaterThan(0, strpos($asset->getContent(), 'Application module not depending on vendor module'), '->filterLoad() compiles a single module with no dependencies');
+    }
+
+    public function testMultiModuleCompile()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/commonjs/indexnovendordeps.js');
+        $asset->load();
+
+        $this->getFilter()->filterLoad($asset);
+
+        $this->assertGreaterThan(0, strpos($asset->getContent(), 'Application module not depending on vendor module'), '->filterLoad() compiles a module with dependencies relative to path');
+    }
+
+    public function testMultiModuleCompileWithIncludePath()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/commonjs/lib/vendordeps.js');
+        $asset->load();
+
+        $filter = $this->getFilter();
+        $filter->setIncludes(array(__DIR__.'/fixtures/commonjs/vendor'));
+        $filter->filterLoad($asset);
+
+        $this->assertGreaterThan(0, strpos($asset->getContent(), 'Vendor module'), '->filterLoad() compiles a module with dependencies in include path');
+    }
+
+    // private
+
+    private function getFilter()
+    {
+        $filter = new CjsDeliveryFilter();
+
+        return $filter;
+    }
+}

--- a/tests/Assetic/Test/Filter/CjsDeliveryFilterTest.php
+++ b/tests/Assetic/Test/Filter/CjsDeliveryFilterTest.php
@@ -59,8 +59,6 @@ class CjsDeliveryFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, strpos($asset->getContent(), 'Vendor module'), '->filterLoad() compiles a module with dependencies in include path');
     }
 
-    // private
-
     private function getFilter()
     {
         $filter = new CjsDeliveryFilter();

--- a/tests/Assetic/Test/Filter/fixtures/commonjs/indexnovendordeps.js
+++ b/tests/Assetic/Test/Filter/fixtures/commonjs/indexnovendordeps.js
@@ -1,0 +1,5 @@
+/**
+ * Application index module with no vendor deps
+ */
+
+exports.m = require('./lib/novendordeps');

--- a/tests/Assetic/Test/Filter/fixtures/commonjs/lib/novendordeps.js
+++ b/tests/Assetic/Test/Filter/fixtures/commonjs/lib/novendordeps.js
@@ -1,0 +1,5 @@
+/**
+ * Application module not depending on vendor module
+ */
+
+exports.v = {msg: 'hi'};

--- a/tests/Assetic/Test/Filter/fixtures/commonjs/lib/vendordeps.js
+++ b/tests/Assetic/Test/Filter/fixtures/commonjs/lib/vendordeps.js
@@ -1,0 +1,5 @@
+/**
+ * Application module depending on vendor module
+ */
+
+exports.v = require('vendordep');


### PR DESCRIPTION
Added a filter to support compilation of CommonJS-format JavaScript modules to a single file, using [cjsDelivery](https://github.com/mattcg/cjsDelivery).

Instead of passing all your JavaScript files to Assetic, you only pass the entry point module ('main' module), which uses the `require` function to require module dependencies as needed.
