### PR TITLE
ENV Variable 'SystemRoot' has to be passed to node process on Windows

### DIFF
--- a/src/Assetic/Filter/BaseNodeFilter.php
+++ b/src/Assetic/Filter/BaseNodeFilter.php
@@ -37,6 +37,12 @@ abstract class BaseNodeFilter extends BaseProcessFilter
         if ($this->nodePaths) {
             $pb->setEnv('NODE_PATH', implode(':', $this->nodePaths));
         }
+        
+        // node.js needs the ENV variable 'SystemRoot' on windows, which is not set automatically
+        // by the Symfony Process Component. See https://github.com/joyent/node/issues/1943#issuecomment-2533452
+        if (isset($_SERVER['SystemRoot'])) {
+            $pb->setEnv('SystemRoot', $_SERVER['SystemRoot']);
+        }
 
         return $pb;
     }


### PR DESCRIPTION
Hi.  
I tried to use LESS with Assetic. But I always got error messages because the node process did not return anything. Neither on STDOUT nor on STDERR. On Linux everything worked fine.
The Symfony Process Component uses `proc_open()` to create and handle the processes. Assetic passes the `NODE_PATH`correctly to the process, but as you can read on https://github.com/joyent/node/issues/1943#issuecomment-2533452 node always need the _'SystemRoot'_ environment variable on Windows Systems.  

I fixed the issue by passing that variable to the process in the [BaseNodeFilter](https://github.com/kriswallsmith/assetic/blob/master/src/Assetic/Filter/BaseNodeFilter.php). I am not sure if this is the right place to do that... maybe you can find a better one ;-)  

Maybe this bug has something to do with [issue #69](https://github.com/kriswallsmith/assetic/issues/69).
