### PR TITLE
Read the description, thanks

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -47,7 +47,9 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
             $this->add($asset);
         }
 
-        $this->filters = new FilterCollection($filters);
+        $this->filters = new FilterCollection(array(
+            'filters' => $filters
+        ));
         $this->sourceRoot = $sourceRoot;
         $this->clones = new \SplObjectStorage();
         $this->vars = $vars;

--- a/src/Assetic/Asset/BaseAsset.php
+++ b/src/Assetic/Asset/BaseAsset.php
@@ -43,7 +43,9 @@ abstract class BaseAsset implements AssetInterface
      */
     public function __construct($filters = array(), $sourceRoot = null, $sourcePath = null, array $vars = array())
     {
-        $this->filters = new FilterCollection($filters);
+        $this->filters = new FilterCollection(array(
+            'filters' => $filters
+        ));
         $this->sourceRoot = $sourceRoot;
         $this->sourcePath = $sourcePath;
         $this->vars = $vars;

--- a/src/Assetic/Filter/BaseCssFilter.php
+++ b/src/Assetic/Filter/BaseCssFilter.php
@@ -18,7 +18,7 @@ use Assetic\Util\CssUtils;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-abstract class BaseCssFilter implements FilterInterface
+abstract class BaseCssFilter extends BaseFilter
 {
     /**
      * @see CssUtils::filterReferences()

--- a/src/Assetic/Filter/BaseFilter.php
+++ b/src/Assetic/Filter/BaseFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+
+abstract class BaseFilter implements FilterInterface
+{
+    /**
+     * @see FitlerInterface::__construct()
+     * @param array $options
+     */
+    public function __construct(array $options = array())
+    {
+        $this->setOptions($options);
+    }
+
+    /**
+     * Automatically calls setter methods based on key of option
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options = array())
+    {
+        foreach ($options as $option => $value) {
+            // test for string option name
+            if (!is_string($option)) {
+                throw new \Exception(get_class($this) . '::setOptions() expects option name to be string, "' . gettype($option) . '" is given');
+            }
+
+            // TODO: do some optimization, regex is too slow
+            $_option = preg_replace('/(?:^|_)(.?)/e', "strtoupper('$1')", $option);
+            $method = 'set' . $_option;
+
+            if (!method_exists($this, $method)) {
+                throw new \Exception(get_class($this) . '::setOptions() unsupported option "' . $option . '", method "' . $method . '" was not found');
+            }
+
+            $this->$method($value);
+        }
+    }
+
+    /**
+     * Filters an asset after it has been loaded.
+     *
+     * @param AssetInterface $asset An asset
+     */
+    abstract public function filterLoad(AssetInterface $asset);
+
+    /**
+     * Filters an asset just before it's dumped.
+     *
+     * @param AssetInterface $asset An asset
+     */
+    abstract public function filterDump(AssetInterface $asset);
+}

--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -17,7 +17,7 @@ use Symfony\Component\Process\ProcessBuilder;
 /**
  * An external process based filter which provides a way to set a timeout on the process.
  */
-abstract class BaseProcessFilter implements FilterInterface
+abstract class BaseProcessFilter extends BaseFilter
 {
     private $timeout;
 

--- a/src/Assetic/Filter/CallablesFilter.php
+++ b/src/Assetic/Filter/CallablesFilter.php
@@ -18,19 +18,29 @@ use Assetic\Asset\AssetInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class CallablesFilter implements FilterInterface
+class CallablesFilter extends BaseFilter implements FilterInterface
 {
     private $loader;
     private $dumper;
 
-    /**
-     * @param callable|null $loader
-     * @param callable|null $dumper
-     */
-    public function __construct($loader = null, $dumper = null)
+    public function setDumper($dumper)
+    {
+        $this->dumper = $dumper;
+    }
+
+    public function getDumper()
+    {
+        return $this->dumper;
+    }
+
+    public function setLoader($loader)
     {
         $this->loader = $loader;
-        $this->dumper = $dumper;
+    }
+
+    public function getLoader()
+    {
+        return $this->loader;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/CoffeeScriptFilter.php
+++ b/src/Assetic/Filter/CoffeeScriptFilter.php
@@ -28,10 +28,24 @@ class CoffeeScriptFilter extends BaseNodeFilter
     // coffee options
     private $bare;
 
-    public function __construct($coffeeBin = '/usr/bin/coffee', $nodeBin = null)
+    public function setCoffeeBin($coffeeBin)
     {
         $this->coffeeBin = $coffeeBin;
+    }
+
+    public function getCoffeeBin()
+    {
+        return $this->coffeeBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
         $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
     }
 
     public function setBare($bare)

--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -54,15 +54,34 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
     private $httpJavascriptsPath;
     private $homeEnv = true;
 
-    public function __construct($compassPath = '/usr/bin/compass', $rubyPath = null)
+    public function __construct(array $options = array())
+    {
+        parent::__construct($options);
+
+        $this->setCacheLocation(sys_get_temp_dir());
+        if ('cli' !== php_sapi_name()) {
+            $this->setBoring(true);
+        }
+    }
+
+    public function setCompassPath($compassPath)
     {
         $this->compassPath = $compassPath;
-        $this->rubyPath = $rubyPath;
-        $this->cacheLocation = sys_get_temp_dir();
+    }
 
-        if ('cli' !== php_sapi_name()) {
-            $this->boring = true;
-        }
+    public function getCompassPath()
+    {
+        return $this->compassPath;
+    }
+
+    public function setRubyPath($rubyPath)
+    {
+        $this->rubyPath = $rubyPath;
+    }
+
+    public function getRubyPath()
+    {
+        return $this->rubyPath;
     }
 
     public function setScss($scss)

--- a/src/Assetic/Filter/CssEmbedFilter.php
+++ b/src/Assetic/Filter/CssEmbedFilter.php
@@ -33,12 +33,6 @@ class CssEmbedFilter extends BaseProcessFilter implements DependencyExtractorInt
     private $maxUriLength; // Maximum length for a data URI. Defaults to 32768.
     private $maxImageSize; // Maximum image size (in bytes) to convert.
 
-    public function __construct($jarPath, $javaPath = '/usr/bin/java')
-    {
-        $this->jarPath = $jarPath;
-        $this->javaPath = $javaPath;
-    }
-
     public function setCharset($charset)
     {
         $this->charset = $charset;

--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -23,21 +23,39 @@ use Assetic\Factory\AssetFactory;
  */
 class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterface
 {
+    /**
+     * @var FilterInterface
+     */
     private $importFilter;
 
     /**
-     * Constructor.
+     * Sets filter for each imported asset
      *
-     * @param FilterInterface $importFilter Filter for each imported asset
+     * @param \Assetic\Filter\FilterInterface $importFilter
      */
-    public function __construct(FilterInterface $importFilter = null)
+    public function setImportFilter(FilterInterface $importFilter)
     {
-        $this->importFilter = $importFilter ?: new CssRewriteFilter();
+        $this->importFilter = $importFilter;
+    }
+
+    /**
+     * Gets filter
+     *
+     * If there is no filter set before, it will set CssRewriteFilter by default
+     *
+     * @return \Assetic\Filter\FilterInterface
+     */
+    public function getImportFilter()
+    {
+        if (!isset($this->importFilter)) {
+            $this->importFilter = new CssRewriteFilter();
+        }
+        return $this->importFilter;
     }
 
     public function filterLoad(AssetInterface $asset)
     {
-        $importFilter = $this->importFilter;
+        $importFilter = $this->getImportFilter();
         $sourceRoot = $asset->getSourceRoot();
         $sourcePath = $asset->getSourcePath();
 

--- a/src/Assetic/Filter/CssMinFilter.php
+++ b/src/Assetic/Filter/CssMinFilter.php
@@ -19,16 +19,10 @@ use Assetic\Asset\AssetInterface;
  * @link http://code.google.com/p/cssmin
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class CssMinFilter implements FilterInterface
+class CssMinFilter extends BaseFilter implements FilterInterface
 {
-    private $filters;
-    private $plugins;
-
-    public function __construct()
-    {
-        $this->filters = array();
-        $this->plugins = array();
-    }
+    private $filters = array();
+    private $plugins = array();
 
     public function setFilters(array $filters)
     {

--- a/src/Assetic/Filter/DartFilter.php
+++ b/src/Assetic/Filter/DartFilter.php
@@ -23,9 +23,14 @@ class DartFilter extends BaseProcessFilter
 {
     private $dartBin;
 
-    public function __construct($dartBin = '/usr/bin/dart2js')
+    public function setDartBin($dartBin)
     {
         $this->dartBin = $dartBin;
+    }
+
+    public function getDartBin()
+    {
+        return $this->dartBin;
     }
 
     public function filterLoad(AssetInterface $asset)
@@ -36,7 +41,7 @@ class DartFilter extends BaseProcessFilter
         file_put_contents($input, $asset->getContent());
 
         $pb = $this->createProcessBuilder()
-            ->add($this->dartBin)
+            ->add($this->getDartBin())
             ->add('-o'.$output)
             ->add($input)
         ;

--- a/src/Assetic/Filter/EmberPrecompileFilter.php
+++ b/src/Assetic/Filter/EmberPrecompileFilter.php
@@ -27,10 +27,24 @@ class EmberPrecompileFilter extends BaseNodeFilter
     private $emberBin;
     private $nodeBin;
 
-    public function __construct($handlebarsBin = '/usr/bin/ember-precompile', $nodeBin = null)
+    public function setEmberBin($emberBin)
     {
-        $this->emberBin = $handlebarsBin;
+        $this->emberBin = $emberBin;
+    }
+
+    public function getEmberBin()
+    {
+        return $this->emberBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
         $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/FilterCollection.php
+++ b/src/Assetic/Filter/FilterCollection.php
@@ -18,15 +18,19 @@ use Assetic\Asset\AssetInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class FilterCollection implements FilterInterface, \IteratorAggregate, \Countable
+class FilterCollection extends BaseFilter implements \IteratorAggregate, \Countable
 {
     private $filters = array();
 
-    public function __construct($filters = array())
+    public function __construct(array $options = array())
     {
-        foreach ($filters as $filter) {
-            $this->ensure($filter);
+        if (isset($options['filters'])) {
+            foreach ($options['filters'] as $filter) {
+                $this->ensure($filter);
+            }
+            unset($options['filters']);
         }
+        parent::__construct($options);
     }
 
     /**

--- a/src/Assetic/Filter/FilterInterface.php
+++ b/src/Assetic/Filter/FilterInterface.php
@@ -21,6 +21,13 @@ use Assetic\Asset\AssetInterface;
 interface FilterInterface
 {
     /**
+     * Array of key-value pairs of options
+     *
+     * @param array $options Key-value options
+     */
+    public function __construct(array $options = array());
+
+    /**
      * Filters an asset after it has been loaded.
      *
      * @param AssetInterface $asset An asset

--- a/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
@@ -50,6 +50,28 @@ abstract class BaseCompilerFilter implements FilterInterface
     protected $warningLevel;
     protected $language;
 
+    /**
+     * @see FitlerInterface::__construct()
+     * @param array $options
+     */
+    public function __construct(array $options = array())
+    {
+        $this->setOptions($options);
+    }
+
+    /**
+     * Automatically calls setter methods based on key of option
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options = array())
+    {
+        foreach ($options as $option => $value) {
+            $option = preg_replace('/(?:^|_)(.?)/e', "strtoupper('$1')", $option);
+            $this->{'set' . $option}($value);
+        }
+    }
+
     public function setTimeout($timeout)
     {
         $this->timeout = $timeout;

--- a/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
@@ -26,10 +26,24 @@ class CompilerJarFilter extends BaseCompilerFilter
     private $jarPath;
     private $javaPath;
 
-    public function __construct($jarPath, $javaPath = '/usr/bin/java')
+    public function setJarPath($jarPath)
     {
         $this->jarPath = $jarPath;
+    }
+
+    public function getJarPath()
+    {
+        return $this->jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
         $this->javaPath = $javaPath;
+    }
+
+    public function getJavaPath()
+    {
+        return $this->javaPath;
     }
 
     public function filterDump(AssetInterface $asset)

--- a/src/Assetic/Filter/GssFilter.php
+++ b/src/Assetic/Filter/GssFilter.php
@@ -33,10 +33,24 @@ class GssFilter extends BaseProcessFilter
     private $outputOrientation;
     private $prettyPrint;
 
-    public function __construct($jarPath, $javaPath = '/usr/bin/java')
+    public function setJarPath($jarPath)
     {
         $this->jarPath = $jarPath;
+    }
+
+    public function getJarPath()
+    {
+        return $this->jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
         $this->javaPath = $javaPath;
+    }
+
+    public function getJavaPath()
+    {
+        return $this->javaPath;
     }
 
     public function setAllowUnrecognizedFunctions($allowUnrecognizedFunctions)

--- a/src/Assetic/Filter/HandlebarsFilter.php
+++ b/src/Assetic/Filter/HandlebarsFilter.php
@@ -28,10 +28,24 @@ class HandlebarsFilter extends BaseNodeFilter
     private $minimize = false;
     private $simple = false;
 
-    public function __construct($handlebarsBin = '/usr/bin/handlebars', $nodeBin = null)
+    public function setHandlebarsBin($handlebarsBin)
     {
         $this->handlebarsBin = $handlebarsBin;
+    }
+
+    public function getHandlebarsBin()
+    {
+        return $this->handlebarsBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
         $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
     }
 
     public function setMinimize($minimize)

--- a/src/Assetic/Filter/JSMinFilter.php
+++ b/src/Assetic/Filter/JSMinFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link https://raw.github.com/mrclay/minify/master/min/lib/JSMin.php
  * @author Brunoais <brunoaiss@gmail.com>
  */
-class JSMinFilter implements FilterInterface
+class JSMinFilter extends BaseFilter
 {
     public function filterLoad(AssetInterface $asset)
     {

--- a/src/Assetic/Filter/JSMinPlusFilter.php
+++ b/src/Assetic/Filter/JSMinPlusFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link https://raw.github.com/mrclay/minify/master/min/lib/JSMinPlus.php
  * @author Brunoais <brunoaiss@gmail.com>
  */
-class JSMinPlusFilter implements FilterInterface
+class JSMinPlusFilter extends BaseFilter
 {
     public function filterLoad(AssetInterface $asset)
     {

--- a/src/Assetic/Filter/JpegoptimFilter.php
+++ b/src/Assetic/Filter/JpegoptimFilter.php
@@ -26,14 +26,14 @@ class JpegoptimFilter extends BaseProcessFilter
     private $stripAll;
     private $max;
 
-    /**
-     * Constructor.
-     *
-     * @param string $jpegoptimBin Path to the jpegoptim binary
-     */
-    public function __construct($jpegoptimBin = '/usr/bin/jpegoptim')
+    public function setJpegoptimBin($jpegoptimBin)
     {
         $this->jpegoptimBin = $jpegoptimBin;
+    }
+
+    public function getJpegoptimBin()
+    {
+        return $this->jpegoptimBin;
     }
 
     public function setStripAll($stripAll)

--- a/src/Assetic/Filter/JpegtranFilter.php
+++ b/src/Assetic/Filter/JpegtranFilter.php
@@ -32,14 +32,14 @@ class JpegtranFilter extends BaseProcessFilter
     private $progressive;
     private $restart;
 
-    /**
-     * Constructor.
-     *
-     * @param string $jpegtranBin Path to the jpegtran binary
-     */
-    public function __construct($jpegtranBin = '/usr/bin/jpegtran')
+    public function setJpegtranBin($jpegtranBin)
     {
         $this->jpegtranBin = $jpegtranBin;
+    }
+
+    public function getJpegtranBin()
+    {
+        return $this->jpegtranBin;
     }
 
     public function setOptimize($optimize)

--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -36,15 +36,29 @@ class LessFilter extends BaseNodeFilter implements DependencyExtractorInterface
     protected $loadPaths = array();
 
     /**
-     * Constructor.
-     *
-     * @param string $nodeBin   The path to the node binary
-     * @param array  $nodePaths An array of node paths
+     * @param array $loadPaths
      */
-    public function __construct($nodeBin = '/usr/bin/node', array $nodePaths = array())
+    public function setLoadPaths($loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLoadPaths()
+    {
+        return $this->loadPaths;
+    }
+
+    public function setNodeBin($nodeBin)
     {
         $this->nodeBin = $nodeBin;
-        $this->setNodePaths($nodePaths);
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
     }
 
     public function setCompress($compress)

--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -24,7 +24,7 @@ use Assetic\Factory\AssetFactory;
  * @author David Buchmann <david@liip.ch>
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class LessphpFilter implements DependencyExtractorInterface
+class LessphpFilter extends BaseFilter implements DependencyExtractorInterface
 {
     private $presets = array();
     private $formatter;

--- a/src/Assetic/Filter/OptiPngFilter.php
+++ b/src/Assetic/Filter/OptiPngFilter.php
@@ -25,14 +25,14 @@ class OptiPngFilter extends BaseProcessFilter
     private $optipngBin;
     private $level;
 
-    /**
-     * Constructor.
-     *
-     * @param string $optipngBin Path to the optipng binary
-     */
-    public function __construct($optipngBin = '/usr/bin/optipng')
+    public function setOptipngBin($optipngBin)
     {
         $this->optipngBin = $optipngBin;
+    }
+
+    public function getOptipngBin()
+    {
+        return $this->optipngBin;
     }
 
     public function setLevel($level)

--- a/src/Assetic/Filter/PackagerFilter.php
+++ b/src/Assetic/Filter/PackagerFilter.php
@@ -19,13 +19,18 @@ use Assetic\Asset\AssetInterface;
  * @link https://github.com/kamicane/packager
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class PackagerFilter implements FilterInterface
+class PackagerFilter extends BaseFilter implements FilterInterface
 {
     private $packages;
 
-    public function __construct(array $packages = array())
+    public function setPackages($packages)
     {
         $this->packages = $packages;
+    }
+
+    public function getPackages()
+    {
+        return $this->packages;
     }
 
     public function addPackage($package)

--- a/src/Assetic/Filter/PackerFilter.php
+++ b/src/Assetic/Filter/PackerFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link http://joliclic.free.fr/php/javascript-packer/en/
  * @author Maximilian Walter <github@max-walter.net>
  */
-class PackerFilter implements FilterInterface
+class PackerFilter extends BaseFilter
 {
     protected $encoding = 'None';
 

--- a/src/Assetic/Filter/PhpCssEmbedFilter.php
+++ b/src/Assetic/Filter/PhpCssEmbedFilter.php
@@ -21,7 +21,7 @@ use CssEmbed\CssEmbed;
  * @author Pierre Tachoire <pierre.tachoire@gmail.com>
  * @link https://github.com/krichprollsch/phpCssEmbed
  */
-class PhpCssEmbedFilter implements DependencyExtractorInterface
+class PhpCssEmbedFilter extends BaseFilter implements DependencyExtractorInterface
 {
     private $presets = array();
 

--- a/src/Assetic/Filter/PngoutFilter.php
+++ b/src/Assetic/Filter/PngoutFilter.php
@@ -50,14 +50,14 @@ class PngoutFilter extends BaseProcessFilter
     private $strategy;
     private $blockSplitThreshold;
 
-    /**
-     * Constructor.
-     *
-     * @param string $pngoutBin Path to the pngout binary
-     */
-    public function __construct($pngoutBin = '/usr/bin/pngout')
+    public function setPngoutBin($pngoutBin)
     {
         $this->pngoutBin = $pngoutBin;
+    }
+
+    public function getPngoutBin()
+    {
+        return $this->pngoutBin;
     }
 
     public function setColor($color)

--- a/src/Assetic/Filter/RooleFilter.php
+++ b/src/Assetic/Filter/RooleFilter.php
@@ -26,16 +26,24 @@ class RooleFilter extends BaseNodeFilter implements DependencyExtractorInterface
     private $rooleBin;
     private $nodeBin;
 
-    /**
-     * Constructor
-     *
-     * @param string $rooleBin The path to the roole binary
-     * @param string $nodeBin  The path to the node binary
-     */
-    public function __construct($rooleBin = '/usr/bin/roole', $nodeBin = null)
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
+    }
+
+    public function setRooleBin($rooleBin)
     {
         $this->rooleBin = $rooleBin;
-        $this->nodeBin = $nodeBin;
+    }
+
+    public function getRooleBin()
+    {
+        return $this->rooleBin;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -44,11 +44,34 @@ class SassFilter extends BaseProcessFilter implements DependencyExtractorInterfa
     private $noCache;
     private $compass;
 
-    public function __construct($sassPath = '/usr/bin/sass', $rubyPath = null)
+    public function setLoadPaths($loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+
+    public function getLoadPaths()
+    {
+        return $this->loadPaths;
+    }
+
+    public function setRubyPath($rubyPath)
+    {
+        $this->rubyPath = $rubyPath;
+    }
+
+    public function getRubyPath()
+    {
+        return $this->rubyPath;
+    }
+
+    public function setSassPath($sassPath)
     {
         $this->sassPath = $sassPath;
-        $this->rubyPath = $rubyPath;
-        $this->cacheLocation = realpath(sys_get_temp_dir());
+    }
+
+    public function getSassPath()
+    {
+        return $this->sassPath;
     }
 
     public function setUnixNewlines($unixNewlines)

--- a/src/Assetic/Filter/Sass/ScssFilter.php
+++ b/src/Assetic/Filter/Sass/ScssFilter.php
@@ -19,9 +19,9 @@ namespace Assetic\Filter\Sass;
  */
 class ScssFilter extends SassFilter
 {
-    public function __construct($sassPath = '/usr/bin/sass', $rubyPath = null)
+    public function __construct(array $options = array())
     {
-        parent::__construct($sassPath, $rubyPath);
+        parent::__construct($options);
 
         $this->setScss(true);
     }

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -23,20 +23,20 @@ use Assetic\Factory\AssetFactory;
  *
  * @author Bart van den Burg <bart@samson-it.nl>
  */
-class ScssphpFilter implements DependencyExtractorInterface
+class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 {
-    private $compass = false;
+    private $compassEnabled = false;
 
     private $importPaths = array();
 
-    public function enableCompass($enable = true)
+    public function setCompassEnabled($compassEnabled)
     {
-        $this->compass = (Boolean) $enable;
+        $this->compassEnabled = $compassEnabled;
     }
 
-    public function isCompassEnabled()
+    public function getCompassEnabled()
     {
-        return $this->compass;
+        return $this->compassEnabled;
     }
 
     public function filterLoad(AssetInterface $asset)
@@ -45,17 +45,22 @@ class ScssphpFilter implements DependencyExtractorInterface
         $path = $asset->getSourcePath();
 
         $lc = new \scssc();
-        if ($this->compass) {
+        if ($this->compassEnabled) {
             new \scss_compass($lc);
         }
         if ($root && $path) {
             $lc->addImportPath(dirname($root.'/'.$path));
         }
-        foreach ($this->importPaths as $path) {
+        foreach ($this->getImportPaths() as $path) {
             $lc->addImportPath($path);
         }
 
         $asset->setContent($lc->compile($asset->getContent()));
+    }
+
+    public function getImportPaths()
+    {
+        return $this->importPaths;
     }
 
     public function setImportPaths(array $paths)

--- a/src/Assetic/Filter/SprocketsFilter.php
+++ b/src/Assetic/Filter/SprocketsFilter.php
@@ -32,17 +32,34 @@ class SprocketsFilter extends BaseProcessFilter implements DependencyExtractorIn
     private $includeDirs;
     private $assetRoot;
 
-    /**
-     * Constructor.
-     *
-     * @param string $sprocketsLib Path to the Sprockets lib/ directory
-     * @param string $rubyBin      Path to the ruby binary
-     */
-    public function __construct($sprocketsLib = null, $rubyBin = '/usr/bin/ruby')
+    public function setIncludeDirs($includeDirs)
+    {
+        $this->includeDirs = $includeDirs;
+    }
+
+    public function getIncludeDirs()
+    {
+        return $this->includeDirs;
+    }
+
+    public function setRubyBin($rubyBin)
+    {
+        $this->rubyBin = $rubyBin;
+    }
+
+    public function getRubyBin()
+    {
+        return $this->rubyBin;
+    }
+
+    public function setSprocketsLib($sprocketsLib)
     {
         $this->sprocketsLib = $sprocketsLib;
-        $this->rubyBin = $rubyBin;
-        $this->includeDirs = array();
+    }
+
+    public function getSprocketsLib()
+    {
+        return $this->sprocketsLib;
     }
 
     public function addIncludeDir($directory)

--- a/src/Assetic/Filter/StylusFilter.php
+++ b/src/Assetic/Filter/StylusFilter.php
@@ -26,16 +26,14 @@ class StylusFilter extends BaseNodeFilter implements DependencyExtractorInterfac
     private $nodeBin;
     private $compress;
 
-    /**
-     * Constructs filter.
-     *
-     * @param string $nodeBin   The path to the node binary
-     * @param array  $nodePaths An array of node paths
-     */
-    public function __construct($nodeBin = '/usr/bin/node', array $nodePaths = array())
+    public function setNodeBin($nodeBin)
     {
         $this->nodeBin = $nodeBin;
-        $this->setNodePaths($nodePaths);
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
     }
 
     /**

--- a/src/Assetic/Filter/TypeScriptFilter.php
+++ b/src/Assetic/Filter/TypeScriptFilter.php
@@ -25,10 +25,24 @@ class TypeScriptFilter extends BaseNodeFilter
     private $tscBin;
     private $nodeBin;
 
-    public function __construct($tscBin = '/usr/bin/tsc', $nodeBin = null)
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
+    }
+
+    public function setTscBin($tscBin)
     {
         $this->tscBin = $tscBin;
-        $this->nodeBin = $nodeBin;
+    }
+
+    public function getTscBin()
+    {
+        return $this->tscBin;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/UglifyCssFilter.php
+++ b/src/Assetic/Filter/UglifyCssFilter.php
@@ -29,14 +29,24 @@ class UglifyCssFilter extends BaseNodeFilter
     private $uglyComments;
     private $cuteComments;
 
-    /**
-     * @param string $uglifycssBin Absolute path to the uglifycss executable
-     * @param string $nodeBin       Absolute path to the folder containg node.js executable
-     */
-    public function __construct($uglifycssBin = '/usr/bin/uglifycss', $nodeBin = null)
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
+    }
+
+    public function setUglifycssBin($uglifycssBin)
     {
         $this->uglifycssBin = $uglifycssBin;
-        $this->nodeBin = $nodeBin;
+    }
+
+    public function getUglifycssBin()
+    {
+        return $this->uglifycssBin;
     }
 
     /**

--- a/src/Assetic/Filter/UglifyJs2Filter.php
+++ b/src/Assetic/Filter/UglifyJs2Filter.php
@@ -30,10 +30,24 @@ class UglifyJs2Filter extends BaseNodeFilter
     private $screwIe8;
     private $comments;
 
-    public function __construct($uglifyjsBin = '/usr/bin/uglifyjs', $nodeBin = null)
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
+    }
+
+    public function setUglifyjsBin($uglifyjsBin)
     {
         $this->uglifyjsBin = $uglifyjsBin;
-        $this->nodeBin = $nodeBin;
+    }
+
+    public function getUglifyjsBin()
+    {
+        return $this->uglifyjsBin;
     }
 
     public function setCompress($compress)

--- a/src/Assetic/Filter/UglifyJsFilter.php
+++ b/src/Assetic/Filter/UglifyJsFilter.php
@@ -30,14 +30,24 @@ class UglifyJsFilter extends BaseNodeFilter
     private $unsafe;
     private $mangle;
 
-    /**
-     * @param string $uglifyjsBin Absolute path to the uglifyjs executable
-     * @param string $nodeBin      Absolute path to the folder containg node.js executable
-     */
-    public function __construct($uglifyjsBin = '/usr/bin/uglifyjs', $nodeBin = null)
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function getNodeBin()
+    {
+        return $this->nodeBin;
+    }
+
+    public function setUglifyjsBin($uglifyjsBin)
     {
         $this->uglifyjsBin = $uglifyjsBin;
-        $this->nodeBin = $nodeBin;
+    }
+
+    public function getUglifyjsBin()
+    {
+        return $this->uglifyjsBin;
     }
 
     /**

--- a/src/Assetic/Filter/Yui/BaseCompressorFilter.php
+++ b/src/Assetic/Filter/Yui/BaseCompressorFilter.php
@@ -29,10 +29,24 @@ abstract class BaseCompressorFilter extends BaseProcessFilter
     private $lineBreak;
     private $stackSize;
 
-    public function __construct($jarPath, $javaPath = '/usr/bin/java')
+    public function setJarPath($jarPath)
     {
         $this->jarPath = $jarPath;
+    }
+
+    public function getJarPath()
+    {
+        return $this->jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
         $this->javaPath = $javaPath;
+    }
+
+    public function getJavaPath()
+    {
+        return $this->javaPath;
     }
 
     public function setCharset($charset)

--- a/tests/Assetic/Test/Asset/AssetCollectionTest.php
+++ b/tests/Assetic/Test/Asset/AssetCollectionTest.php
@@ -48,12 +48,14 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
 
         $count = 0;
         $matches = array();
-        $filter = new CallablesFilter(function($asset) use ($content, &$matches, &$count) {
-            ++$count;
-            if ($content == $asset->getContent()) {
-                $matches[] = $asset;
+        $filter = new CallablesFilter(array(
+            'loader' => function($asset) use ($content, &$matches, &$count) {
+                ++$count;
+                if ($content == $asset->getContent()) {
+                    $matches[] = $asset;
+                }
             }
-        });
+        ));
 
         $innerColl = new AssetCollection(array(new StringAsset($content)));
         $outerColl = new AssetCollection(array($innerColl), array($filter));
@@ -70,9 +72,11 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
         $innerColl = new AssetCollection(array($nestedAsset));
 
         $contents = array();
-        $filter = new CallablesFilter(function($asset) use (&$contents) {
-            $contents[] = $asset->getContent();
-        });
+        $filter = new CallablesFilter(array(
+            'loader' => function($asset) use (&$contents) {
+                $contents[] = $asset->getContent();
+            }
+        ));
 
         $coll = new AssetCollection(array($asset, $innerColl), array($filter));
         $coll->load();
@@ -125,7 +129,9 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
     public function testIterationFilters()
     {
         $count = 0;
-        $filter = new CallablesFilter(function() use (&$count) { ++$count; });
+        $filter = new CallablesFilter(array(
+            'loader' => function() use (&$count) { ++$count; }
+        ));
 
         $coll = new AssetCollection();
         $coll->add(new StringAsset(''));

--- a/tests/Assetic/Test/Filter/BaseFilterTest.php
+++ b/tests/Assetic/Test/Filter/BaseFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Filter\BaseFilter;
+use Assetic\Asset\AssetInterface;
+
+class BaseFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInterface()
+    {
+        $filter = new BaseFilterFilter();
+        $this->assertInstanceOf('Assetic\\Filter\\FilterInterface', $filter, 'BaseFilterFilter implements FilterInterface');
+    }
+
+    private function _getTestOptionsArray()
+    {
+        return array(
+            'test_option_camel_case' => array('test', 'asd' => 'dsa'),
+            'testoptionalllowercase' => true,
+        );
+    }
+
+    public function testSetOptions()
+    {
+        $options = $this->_getTestOptionsArray();
+        $filter = new BaseFilterFilter();
+        $filter->setOptions($options);
+        $this->assertEquals($options['test_option_camel_case'], $filter->getTestOptionCamelCase(), 'BaseFilterFilter setOptions sets camelCase options');
+        $this->assertEquals($options['testoptionalllowercase'], $filter->getTestoptionalllowercase(), 'BaseFilterFilter setOptions sets lowercase options');
+    }
+
+    public function testConstructor()
+    {
+        $options = $this->_getTestOptionsArray();
+        $filter = new BaseFilterFilter($options);
+        $this->assertEquals($options, array(
+            'test_option_camel_case' => $filter->getTestOptionCamelCase(),
+            'testoptionalllowercase' => $filter->getTestoptionalllowercase()
+        ), 'BaseFilterFilter __construct sets options');
+    }
+
+    public function testUnsupportedOption()
+    {
+        $options = array_merge(
+            $this->_getTestOptionsArray(),
+            array('unsupported_option' => 'test')
+        );
+        $filter = new BaseFilterFilter();
+        $this->setExpectedException('\Exception', 'Assetic\Test\Filter\BaseFilterFilter::setOptions() unsupported option "unsupported_option", method "setUnsupportedOption" was not found');
+        $filter->setOptions($options);
+    }
+
+    public function testNonStringOptionNameType()
+    {
+        $options = array_merge(
+            $this->_getTestOptionsArray(),
+            array(123 => 'asd')
+        );
+        $filter = new BaseFilterFilter();
+        $this->setExpectedException('\Exception', 'Assetic\Test\Filter\BaseFilterFilter::setOptions() expects option name to be string, "integer" is given');
+        $filter->setOptions($options);
+    }
+}
+
+class BaseFilterFilter extends BaseFilter
+{
+    protected $testOptionCamelCase;
+
+    protected $testoptionalllowercase;
+
+    public function setTestOptionCamelCase($testOptionCamelCase)
+    {
+        $this->testOptionCamelCase = $testOptionCamelCase;
+    }
+
+    public function getTestOptionCamelCase()
+    {
+        return $this->testOptionCamelCase;
+    }
+
+    public function setTestoptionalllowercase($testoptionalllowercase)
+    {
+        $this->testoptionalllowercase = $testoptionalllowercase;
+    }
+
+    public function getTestoptionalllowercase()
+    {
+        return $this->testoptionalllowercase;
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+    }
+}

--- a/tests/Assetic/Test/Filter/CallablesFilterTest.php
+++ b/tests/Assetic/Test/Filter/CallablesFilterTest.php
@@ -24,7 +24,9 @@ class CallablesFilterTest extends \PHPUnit_Framework_TestCase
     public function testLoader()
     {
         $nb = 0;
-        $filter = new CallablesFilter(function($asset) use (&$nb) { $nb++; });
+        $filter = new CallablesFilter(array(
+            'loader' => function($asset) use (&$nb) { $nb++; }
+        ));
         $filter->filterLoad($this->getMock('Assetic\\Asset\\AssetInterface'));
         $this->assertEquals(1, $nb, '->filterLoad() calls the loader callable');
     }
@@ -32,7 +34,9 @@ class CallablesFilterTest extends \PHPUnit_Framework_TestCase
     public function testDumper()
     {
         $nb = 0;
-        $filter = new CallablesFilter(null, function($asset) use (&$nb) { $nb++; });
+        $filter = new CallablesFilter(array(
+            'dumper' => function($asset) use (&$nb) { $nb++; }
+        ));
         $filter->filterDump($this->getMock('Assetic\\Asset\\AssetInterface'));
         $this->assertEquals(1, $nb, '->filterDump() calls the loader callable');
     }

--- a/tests/Assetic/Test/Filter/CssMinFilterTest.php
+++ b/tests/Assetic/Test/Filter/CssMinFilterTest.php
@@ -31,7 +31,7 @@ class CssMinFilterTest extends \PHPUnit_Framework_TestCase
         $asset = new FileAsset(__DIR__.'/fixtures/cssmin/main.css');
         $asset->load();
 
-        $filter = new CssMinFilter(__DIR__.'/fixtures/cssmin');
+        $filter = new CssMinFilter();
         $filter->setFilter('ImportImports', true);
         $filter->filterDump($asset);
 

--- a/tests/Assetic/Test/Filter/FilterCollectionTest.php
+++ b/tests/Assetic/Test/Filter/FilterCollectionTest.php
@@ -37,8 +37,10 @@ class FilterCollectionTest extends \PHPUnit_Framework_TestCase
     public function testAll()
     {
         $filter = new FilterCollection(array(
-            $this->getMock('Assetic\\Filter\\FilterInterface'),
-            $this->getMock('Assetic\\Filter\\FilterInterface'),
+            'filters' => array(
+                $this->getMock('Assetic\\Filter\\FilterInterface'),
+                $this->getMock('Assetic\\Filter\\FilterInterface'),
+            )
         ));
 
         $this->assertInternalType('array', $filter->all(), '->all() returns an array');
@@ -52,7 +54,9 @@ class FilterCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testCountable()
     {
-        $filters = new FilterCollection(array($this->getMock('Assetic\\Filter\\FilterInterface')));
+        $filters = new FilterCollection(array(
+            'filters' => array($this->getMock('Assetic\\Filter\\FilterInterface')))
+        );
 
         $this->assertEquals(1, count($filters), 'Countable returns the count');
     }

--- a/tests/Assetic/Test/Filter/JpegtranFilterTest.php
+++ b/tests/Assetic/Test/Filter/JpegtranFilterTest.php
@@ -27,7 +27,9 @@ class JpegtranFilterTest extends FilterTestCase
             $this->markTestSkipped('Unable to find `jpegtran` executable.');
         }
 
-        $this->filter = new JpegtranFilter($jpegtranBin);
+        $this->filter = new JpegtranFilter(array(
+            'jpegtran_bin' => $jpegtranBin
+        ));
     }
 
     protected function tearDown()

--- a/tests/Assetic/Test/Filter/Yui/BaseCompressorFilterTest.php
+++ b/tests/Assetic/Test/Filter/Yui/BaseCompressorFilterTest.php
@@ -18,7 +18,9 @@ class BaseCompressorFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testInterface()
     {
-        $filter = new YuiCompressorFilterForTest('/path/to/jar');
+        $filter = new YuiCompressorFilterForTest(array(
+            'jar_path' => '/path/to/jar'
+        ));
         $this->assertInstanceOf('Assetic\\Filter\\FilterInterface', $filter, 'BaseCompressorFilter implements FilterInterface');
     }
 }

--- a/tests/Assetic/Test/Filter/Yui/CssCompressorFilterTest.php
+++ b/tests/Assetic/Test/Filter/Yui/CssCompressorFilterTest.php
@@ -17,7 +17,9 @@ class CssCompressorFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testInterface()
     {
-        $filter = new CssCompressorFilter('/path/to/jar');
+        $filter = new CssCompressorFilter(array(
+            'jar_path' => '/path/to/jar'
+        ));
         $this->assertInstanceOf('Assetic\\Filter\\FilterInterface', $filter, 'CssCompressorFilter implements FilterInterface');
     }
 }

--- a/tests/Assetic/Test/Filter/Yui/JsCompressorFilterTest.php
+++ b/tests/Assetic/Test/Filter/Yui/JsCompressorFilterTest.php
@@ -19,7 +19,9 @@ class JsCompressorFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testInterface()
     {
-        $filter = new JsCompressorFilter('/path/to/jar');
+        $filter = new JsCompressorFilter(array(
+            'jar_path' => '/path/to/jar'
+        ));
         $this->assertInstanceOf('Assetic\\Filter\\FilterInterface', $filter, 'JsCompressorFilter implements FilterInterface');
     }
 


### PR DESCRIPTION
1.  Created `BaseFilter` class. There is `BaseFilter::setOptions()` which will call setters for each option, this method is automatically being called from constructor
2.  Now all filters extend from `BaseFilter`, so all filter options must be converted to key-value paired array
3.  Added test for `BaseFilter` methods and option name validation
4.  Corrected all tests to pass single key-value paired array to filter constructor
### WARNING

This commit will make the whole project **INCOMPATIBLE** with current version!!!

Note: it is _possible_ to preserve _back-compatibility_ with current version. To achieve that:
1.  `FilterInterface::__construct()` must be removed
2.  All modifications of `*Filter` classes must be rolled back
3.  All `*Filter` classes must extend from `BaseFilter`
4.  All tests must be rolled back
5.  In `BaseFilterTest` the test of constructor must be removed

But I think it is more **consistent** to force all filters to have same constructor (maybe this should be postponed for new version).
#### Purpose of This Commit

https://github.com/widmogrod/zf2-assetic-module
As you know this project is using Assetic.

Currently the configuration file of AsseticModule looks like the following:

``` php
<?php
return array(
'assetic_configuration' => array(
    'modules' => array(
        /*
         * Application moodule - assets configuration
         */
        'application' => array(
            'root_path' => __DIR__ . '/../assets',

            'collections' => array(
                'base_css' => array(
                    'assets' => array(
                        'css/bootstrap-responsive.min.css',
                        'css/style.css',
                        'css/bootstrap.min.css',
                    ),
                    'filters' => array(
                        'CssRewriteFilter' => array(
                            'name' => 'Assetic\Filter\LessFilter',
  /* attention ==> */       'option' => array(
                                '/usr/bin/node', // first argument of constructor
                                array('/usr/local/lib/node_modules'), // second argument
                            ),
                        ),
                    ),
                    'options' => array(),
                ),
            ),
        ),
    ),
),
);
```

In my opinion it will seem more _natively-integrated_, if it will look like this:

``` php
<?php
// ...
array(
    'filters' => array(
        'CssRewriteFilter' => array(
            'name' => 'Assetic\Filter\LessFilter',
            'options' => array(
                'node_bin' => '/usr/bin/node',
                'node_path' => array('/usr/local/lib/node_modules'),
            ),
        ),
    ),
);
```

I think you will agree, this looks more _friendly_ and more _self-descriptive_

To achieve this all filters must have at least `::setOptions()` method.
#### BIG TODO

README.md must be updated according to this commit
