### PR TITLE
Added setOptions() method to all filters

### DIFF
--- a/src/Assetic/Filter/BaseCssFilter.php
+++ b/src/Assetic/Filter/BaseCssFilter.php
@@ -18,7 +18,7 @@ use Assetic\Util\CssUtils;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-abstract class BaseCssFilter implements FilterInterface
+abstract class BaseCssFilter extends BaseFilter
 {
     /**
      * @see CssUtils::filterReferences()

--- a/src/Assetic/Filter/BaseFilter.php
+++ b/src/Assetic/Filter/BaseFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Assetic\Filter;
+
+use Assetic\Exception\FilterException;
+
+abstract class BaseFilter implements FilterInterface
+{
+    /**
+     * @see FilterInterface::setOptions()
+     *
+     * @throws FilterException If $options contains invalid/unsupported option name
+     * @param array $options
+     */
+    public function setOptions(array $options)
+    {
+        foreach ($options as $option => $value) {
+            // require only string option name
+            if (!is_string($option)) {
+                throw new FilterException(get_class($this) . '::setOptions() expects option name to be string, "' . gettype($option) . '" is given');
+            }
+
+            $camelCaseOption = self::camelCase($option);
+            $method = 'set' . $camelCaseOption;
+
+            if (!method_exists($this, $method)) {
+                throw new FilterException(get_class($this) . '::setOptions() unsupported option "' . $option . '", method "' . $method . '" was not found');
+            }
+
+            $this->$method($value);
+        }
+    }
+
+    /**
+     * @see FilterInterface::isOptionSupported()
+     *
+     * @param $option
+     * @return bool
+     */
+    public function isOptionSupported($option)
+    {
+        $camelCaseOption = self::camelCase($option);
+        $method = 'set' . $camelCaseOption;
+
+        return method_exists($this, $method);
+    }
+
+    /**
+     * Makes provided string camelCased
+     *
+     * @param $string
+     * @param bool $capitalizeFirstCharacter
+     * @param string $separator
+     * @return string
+     */
+    static private function camelCase($string, $capitalizeFirstCharacter = true, $separator = '_')
+    {
+        $string = str_replace(' ', '', ucwords(str_replace($separator, ' ', $string)));
+
+        if (!$capitalizeFirstCharacter) {
+            $string[0] = strtolower($string[0]);
+        }
+
+        return $string;
+    }
+}

--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -17,7 +17,7 @@ use Symfony\Component\Process\ProcessBuilder;
 /**
  * An external process based filter which provides a way to set a timeout on the process.
  */
-abstract class BaseProcessFilter implements FilterInterface
+abstract class BaseProcessFilter extends BaseFilter
 {
     private $timeout;
 

--- a/src/Assetic/Filter/CallablesFilter.php
+++ b/src/Assetic/Filter/CallablesFilter.php
@@ -18,7 +18,7 @@ use Assetic\Asset\AssetInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class CallablesFilter implements FilterInterface
+class CallablesFilter extends BaseFilter
 {
     private $loader;
     private $dumper;
@@ -31,6 +31,16 @@ class CallablesFilter implements FilterInterface
     {
         $this->loader = $loader;
         $this->dumper = $dumper;
+    }
+
+    public function setDumper($dumper)
+    {
+        $this->dumper = $dumper;
+    }
+
+    public function setLoader($loader)
+    {
+        $this->loader = $loader;
     }
 
     public function filterLoad(AssetInterface $asset)

--- a/src/Assetic/Filter/CoffeeScriptFilter.php
+++ b/src/Assetic/Filter/CoffeeScriptFilter.php
@@ -34,6 +34,16 @@ class CoffeeScriptFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setCoffeeBin($coffeeBin)
+    {
+        $this->coffeeBin = $coffeeBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
     public function setBare($bare)
     {
         $this->bare = $bare;

--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -65,6 +65,16 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
         }
     }
 
+    public function setCompassPath($compassPath)
+    {
+        $this->compassPath = $compassPath;
+    }
+
+    public function setRubyPath($rubyPath)
+    {
+        $this->rubyPath = $rubyPath;
+    }
+
     public function setScss($scss)
     {
         $this->scss = $scss;

--- a/src/Assetic/Filter/CssEmbedFilter.php
+++ b/src/Assetic/Filter/CssEmbedFilter.php
@@ -39,6 +39,16 @@ class CssEmbedFilter extends BaseProcessFilter implements DependencyExtractorInt
         $this->javaPath = $javaPath;
     }
 
+    public function setJarPath($jarPath)
+    {
+        $this->jarPath = $jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
+        $this->javaPath = $javaPath;
+    }
+
     public function setCharset($charset)
     {
         $this->charset = $charset;

--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -35,6 +35,11 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
         $this->importFilter = $importFilter ?: new CssRewriteFilter();
     }
 
+    public function setImportFilter($importFilter)
+    {
+        $this->importFilter = $importFilter;
+    }
+
     public function filterLoad(AssetInterface $asset)
     {
         $importFilter = $this->importFilter;

--- a/src/Assetic/Filter/CssMinFilter.php
+++ b/src/Assetic/Filter/CssMinFilter.php
@@ -19,7 +19,7 @@ use Assetic\Asset\AssetInterface;
  * @link http://code.google.com/p/cssmin
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class CssMinFilter implements FilterInterface
+class CssMinFilter extends BaseFilter
 {
     private $filters;
     private $plugins;

--- a/src/Assetic/Filter/DartFilter.php
+++ b/src/Assetic/Filter/DartFilter.php
@@ -28,6 +28,11 @@ class DartFilter extends BaseProcessFilter
         $this->dartBin = $dartBin;
     }
 
+    public function setDartBin($dartBin)
+    {
+        $this->dartBin = $dartBin;
+    }
+
     public function filterLoad(AssetInterface $asset)
     {
         $input  = tempnam(sys_get_temp_dir(), 'assetic_dart');

--- a/src/Assetic/Filter/EmberPrecompileFilter.php
+++ b/src/Assetic/Filter/EmberPrecompileFilter.php
@@ -33,6 +33,16 @@ class EmberPrecompileFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setEmberBin($emberBin)
+    {
+        $this->emberBin = $emberBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
     public function filterLoad(AssetInterface $asset)
     {
         $pb = $this->createProcessBuilder($this->nodeBin

--- a/src/Assetic/Filter/FilterCollection.php
+++ b/src/Assetic/Filter/FilterCollection.php
@@ -18,11 +18,16 @@ use Assetic\Asset\AssetInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class FilterCollection implements FilterInterface, \IteratorAggregate, \Countable
+class FilterCollection extends BaseFilter implements \IteratorAggregate, \Countable
 {
     private $filters = array();
 
     public function __construct($filters = array())
+    {
+        $this->setFilters($filters);
+    }
+
+    public function setFilters($filters)
     {
         foreach ($filters as $filter) {
             $this->ensure($filter);

--- a/src/Assetic/Filter/FilterInterface.php
+++ b/src/Assetic/Filter/FilterInterface.php
@@ -21,6 +21,22 @@ use Assetic\Asset\AssetInterface;
 interface FilterInterface
 {
     /**
+     * Automatically calls setter methods based on name of option
+     *
+     * @throws FilterException If $options contains invalid/unsupported option name
+     * @param array $options
+     */
+    public function setOptions(array $options);
+
+    /**
+     * Checks if this filter has setter method for the provided option
+     *
+     * @param $option
+     * @return bool
+     */
+    public function isOptionSupported($option);
+
+    /**
      * Filters an asset after it has been loaded.
      *
      * @param AssetInterface $asset An asset

--- a/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/BaseCompilerFilter.php
@@ -12,6 +12,7 @@
 namespace Assetic\Filter\GoogleClosure;
 
 use Assetic\Asset\AssetInterface;
+use Assetic\Filter\BaseFilter;
 use Assetic\Filter\FilterInterface;
 
 /**
@@ -19,7 +20,7 @@ use Assetic\Filter\FilterInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-abstract class BaseCompilerFilter implements FilterInterface
+abstract class BaseCompilerFilter extends BaseFilter
 {
     // compilation levels
     const COMPILE_WHITESPACE_ONLY = 'WHITESPACE_ONLY';

--- a/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
@@ -32,6 +32,16 @@ class CompilerJarFilter extends BaseCompilerFilter
         $this->javaPath = $javaPath;
     }
 
+    public function setJarPath($jarPath)
+    {
+        $this->jarPath = $jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
+        $this->javaPath = $javaPath;
+    }
+
     public function filterDump(AssetInterface $asset)
     {
         $cleanup = array();

--- a/src/Assetic/Filter/GssFilter.php
+++ b/src/Assetic/Filter/GssFilter.php
@@ -39,6 +39,16 @@ class GssFilter extends BaseProcessFilter
         $this->javaPath = $javaPath;
     }
 
+    public function setJarPath($jarPath)
+    {
+        $this->jarPath = $jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
+        $this->javaPath = $javaPath;
+    }
+
     public function setAllowUnrecognizedFunctions($allowUnrecognizedFunctions)
     {
         $this->allowUnrecognizedFunctions = $allowUnrecognizedFunctions;

--- a/src/Assetic/Filter/HandlebarsFilter.php
+++ b/src/Assetic/Filter/HandlebarsFilter.php
@@ -34,6 +34,16 @@ class HandlebarsFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setHandlebarsBin($handlebarsBin)
+    {
+        $this->handlebarsBin = $handlebarsBin;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
     public function setMinimize($minimize)
     {
         $this->minimize = $minimize;

--- a/src/Assetic/Filter/JSMinFilter.php
+++ b/src/Assetic/Filter/JSMinFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link https://raw.github.com/mrclay/minify/master/min/lib/JSMin.php
  * @author Brunoais <brunoaiss@gmail.com>
  */
-class JSMinFilter implements FilterInterface
+class JSMinFilter extends BaseFilter
 {
     public function filterLoad(AssetInterface $asset)
     {

--- a/src/Assetic/Filter/JSMinPlusFilter.php
+++ b/src/Assetic/Filter/JSMinPlusFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link https://raw.github.com/mrclay/minify/master/min/lib/JSMinPlus.php
  * @author Brunoais <brunoaiss@gmail.com>
  */
-class JSMinPlusFilter implements FilterInterface
+class JSMinPlusFilter extends BaseFilter
 {
     public function filterLoad(AssetInterface $asset)
     {

--- a/src/Assetic/Filter/JpegoptimFilter.php
+++ b/src/Assetic/Filter/JpegoptimFilter.php
@@ -36,6 +36,11 @@ class JpegoptimFilter extends BaseProcessFilter
         $this->jpegoptimBin = $jpegoptimBin;
     }
 
+    public function setJpegoptimBin($jpegoptimBin)
+    {
+        $this->jpegoptimBin = $jpegoptimBin;
+    }
+
     public function setStripAll($stripAll)
     {
         $this->stripAll = $stripAll;

--- a/src/Assetic/Filter/JpegtranFilter.php
+++ b/src/Assetic/Filter/JpegtranFilter.php
@@ -42,6 +42,11 @@ class JpegtranFilter extends BaseProcessFilter
         $this->jpegtranBin = $jpegtranBin;
     }
 
+    public function setJpegtranBin($jpegtranBin)
+    {
+        $this->jpegtranBin = $jpegtranBin;
+    }
+
     public function setOptimize($optimize)
     {
         $this->optimize = $optimize;

--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -47,6 +47,19 @@ class LessFilter extends BaseNodeFilter implements DependencyExtractorInterface
         $this->setNodePaths($nodePaths);
     }
 
+    /**
+     * @param array $loadPaths
+     */
+    public function setLoadPaths($loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
     public function setCompress($compress)
     {
         $this->compress = $compress;

--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -24,7 +24,7 @@ use Assetic\Factory\AssetFactory;
  * @author David Buchmann <david@liip.ch>
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class LessphpFilter implements DependencyExtractorInterface
+class LessphpFilter extends BaseFilter implements DependencyExtractorInterface
 {
     private $presets = array();
     private $formatter;

--- a/src/Assetic/Filter/OptiPngFilter.php
+++ b/src/Assetic/Filter/OptiPngFilter.php
@@ -35,6 +35,11 @@ class OptiPngFilter extends BaseProcessFilter
         $this->optipngBin = $optipngBin;
     }
 
+    public function setOptipngBin($optipngBin)
+    {
+        $this->optipngBin = $optipngBin;
+    }
+
     public function setLevel($level)
     {
         $this->level = $level;

--- a/src/Assetic/Filter/PackagerFilter.php
+++ b/src/Assetic/Filter/PackagerFilter.php
@@ -19,11 +19,16 @@ use Assetic\Asset\AssetInterface;
  * @link https://github.com/kamicane/packager
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class PackagerFilter implements FilterInterface
+class PackagerFilter extends BaseFilter
 {
     private $packages;
 
     public function __construct(array $packages = array())
+    {
+        $this->packages = $packages;
+    }
+
+    public function setPackages($packages)
     {
         $this->packages = $packages;
     }

--- a/src/Assetic/Filter/PackerFilter.php
+++ b/src/Assetic/Filter/PackerFilter.php
@@ -21,7 +21,7 @@ use Assetic\Asset\AssetInterface;
  * @link http://joliclic.free.fr/php/javascript-packer/en/
  * @author Maximilian Walter <github@max-walter.net>
  */
-class PackerFilter implements FilterInterface
+class PackerFilter extends BaseFilter
 {
     protected $encoding = 'None';
 

--- a/src/Assetic/Filter/PhpCssEmbedFilter.php
+++ b/src/Assetic/Filter/PhpCssEmbedFilter.php
@@ -21,7 +21,7 @@ use CssEmbed\CssEmbed;
  * @author Pierre Tachoire <pierre.tachoire@gmail.com>
  * @link https://github.com/krichprollsch/phpCssEmbed
  */
-class PhpCssEmbedFilter implements DependencyExtractorInterface
+class PhpCssEmbedFilter extends BaseFilter
 {
     private $presets = array();
 

--- a/src/Assetic/Filter/PngoutFilter.php
+++ b/src/Assetic/Filter/PngoutFilter.php
@@ -60,6 +60,11 @@ class PngoutFilter extends BaseProcessFilter
         $this->pngoutBin = $pngoutBin;
     }
 
+    public function setPngoutBin($pngoutBin)
+    {
+        $this->pngoutBin = $pngoutBin;
+    }
+
     public function setColor($color)
     {
         $this->color = $color;

--- a/src/Assetic/Filter/RooleFilter.php
+++ b/src/Assetic/Filter/RooleFilter.php
@@ -38,6 +38,16 @@ class RooleFilter extends BaseNodeFilter implements DependencyExtractorInterface
         $this->nodeBin = $nodeBin;
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function setRooleBin($rooleBin)
+    {
+        $this->rooleBin = $rooleBin;
+    }
+
     public function filterLoad(AssetInterface $asset)
     {
         $input = tempnam(sys_get_temp_dir(), 'assetic_roole');

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -51,6 +51,21 @@ class SassFilter extends BaseProcessFilter implements DependencyExtractorInterfa
         $this->cacheLocation = realpath(sys_get_temp_dir());
     }
 
+    public function setLoadPaths($loadPaths)
+    {
+        $this->loadPaths = $loadPaths;
+    }
+
+    public function setRubyPath($rubyPath)
+    {
+        $this->rubyPath = $rubyPath;
+    }
+
+    public function setSassPath($sassPath)
+    {
+        $this->sassPath = $sassPath;
+    }
+
     public function setUnixNewlines($unixNewlines)
     {
         $this->unixNewlines = $unixNewlines;

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -23,11 +23,16 @@ use Assetic\Factory\AssetFactory;
  *
  * @author Bart van den Burg <bart@samson-it.nl>
  */
-class ScssphpFilter implements DependencyExtractorInterface
+class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 {
     private $compass = false;
 
     private $importPaths = array();
+
+    public function setCompass($compass)
+    {
+        $this->compass = $compass;
+    }
 
     public function enableCompass($enable = true)
     {

--- a/src/Assetic/Filter/SprocketsFilter.php
+++ b/src/Assetic/Filter/SprocketsFilter.php
@@ -45,6 +45,21 @@ class SprocketsFilter extends BaseProcessFilter implements DependencyExtractorIn
         $this->includeDirs = array();
     }
 
+    public function setIncludeDirs($includeDirs)
+    {
+        $this->includeDirs = $includeDirs;
+    }
+
+    public function setRubyBin($rubyBin)
+    {
+        $this->rubyBin = $rubyBin;
+    }
+
+    public function setSprocketsLib($sprocketsLib)
+    {
+        $this->sprocketsLib = $sprocketsLib;
+    }
+
     public function addIncludeDir($directory)
     {
         $this->includeDirs[] = $directory;

--- a/src/Assetic/Filter/StylusFilter.php
+++ b/src/Assetic/Filter/StylusFilter.php
@@ -38,6 +38,11 @@ class StylusFilter extends BaseNodeFilter implements DependencyExtractorInterfac
         $this->setNodePaths($nodePaths);
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
     /**
      * Enable output compression.
      *

--- a/src/Assetic/Filter/TypeScriptFilter.php
+++ b/src/Assetic/Filter/TypeScriptFilter.php
@@ -31,6 +31,16 @@ class TypeScriptFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function setTscBin($tscBin)
+    {
+        $this->tscBin = $tscBin;
+    }
+
     public function filterLoad(AssetInterface $asset)
     {
         $pb = $this->createProcessBuilder($this->nodeBin

--- a/src/Assetic/Filter/UglifyCssFilter.php
+++ b/src/Assetic/Filter/UglifyCssFilter.php
@@ -39,6 +39,16 @@ class UglifyCssFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function setUglifycssBin($uglifycssBin)
+    {
+        $this->uglifycssBin = $uglifycssBin;
+    }
+
     /**
      * Expand variables
      * @param bool $expandVars True to enable

--- a/src/Assetic/Filter/UglifyJs2Filter.php
+++ b/src/Assetic/Filter/UglifyJs2Filter.php
@@ -36,6 +36,16 @@ class UglifyJs2Filter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function setUglifyjsBin($uglifyjsBin)
+    {
+        $this->uglifyjsBin = $uglifyjsBin;
+    }
+
     public function setCompress($compress)
     {
         $this->compress = $compress;

--- a/src/Assetic/Filter/UglifyJsFilter.php
+++ b/src/Assetic/Filter/UglifyJsFilter.php
@@ -40,6 +40,16 @@ class UglifyJsFilter extends BaseNodeFilter
         $this->nodeBin = $nodeBin;
     }
 
+    public function setNodeBin($nodeBin)
+    {
+        $this->nodeBin = $nodeBin;
+    }
+
+    public function setUglifyjsBin($uglifyjsBin)
+    {
+        $this->uglifyjsBin = $uglifyjsBin;
+    }
+
     /**
      * Removes the first block of comments as well
      * @param bool $noCopyright True to enable

--- a/src/Assetic/Filter/Yui/BaseCompressorFilter.php
+++ b/src/Assetic/Filter/Yui/BaseCompressorFilter.php
@@ -35,6 +35,16 @@ abstract class BaseCompressorFilter extends BaseProcessFilter
         $this->javaPath = $javaPath;
     }
 
+    public function setJarPath($jarPath)
+    {
+        $this->jarPath = $jarPath;
+    }
+
+    public function setJavaPath($javaPath)
+    {
+        $this->javaPath = $javaPath;
+    }
+
     public function setCharset($charset)
     {
         $this->charset = $charset;

--- a/tests/Assetic/Test/Filter/BaseFilterTest.php
+++ b/tests/Assetic/Test/Filter/BaseFilterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Filter\BaseFilter;
+use Assetic\Asset\AssetInterface;
+
+class BaseFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInterface()
+    {
+        $filter = new BaseFilterFilter();
+        $this->assertInstanceOf('Assetic\\Filter\\FilterInterface', $filter, 'BaseFilterFilter implements FilterInterface');
+    }
+
+    private function _getTestOptionsArray()
+    {
+        return array(
+            'test_option_camel_case' => array('test', 'asd' => 'dsa'),
+            'testoptionalllowercase' => true,
+        );
+    }
+
+    public function testSetOptions()
+    {
+        $options = $this->_getTestOptionsArray();
+        $filter = new BaseFilterFilter();
+        $filter->setOptions($options);
+        $this->assertEquals($options['test_option_camel_case'], $filter->getTestOptionCamelCase(), 'BaseFilterFilter setOptions sets camelCase options');
+        $this->assertEquals($options['testoptionalllowercase'], $filter->getTestoptionalllowercase(), 'BaseFilterFilter setOptions sets lowercase options');
+    }
+
+    public function testUnsupportedOption()
+    {
+        $options = array_merge(
+            $this->_getTestOptionsArray(),
+            array('unsupported_option' => 'test')
+        );
+        $filter = new BaseFilterFilter();
+        $this->setExpectedException('\Assetic\Exception\FilterException', 'Assetic\Test\Filter\BaseFilterFilter::setOptions() unsupported option "unsupported_option", method "setUnsupportedOption" was not found');
+        $filter->setOptions($options);
+    }
+
+    public function testNonStringOptionNameType()
+    {
+        $options = array_merge(
+            $this->_getTestOptionsArray(),
+            array(123 => 'asd')
+        );
+        $filter = new BaseFilterFilter();
+        $this->setExpectedException('\Assetic\Exception\FilterException', 'Assetic\Test\Filter\BaseFilterFilter::setOptions() expects option name to be string, "integer" is given');
+        $filter->setOptions($options);
+    }
+
+    public function testIsOptionSupported()
+    {
+        $filter = new BaseFilterFilter();
+        $this->assertEquals(true, $filter->isOptionSupported('test_option_camel_case'));
+        $this->assertEquals(true, $filter->isOptionSupported('testoptionalllowercase'));
+        $this->assertEquals(false, $filter->isOptionSupported('nonexistent_option'));
+    }
+}
+
+class BaseFilterFilter extends BaseFilter
+{
+    protected $testOptionCamelCase;
+
+    protected $testoptionalllowercase;
+
+    public function setTestOptionCamelCase($testOptionCamelCase)
+    {
+        $this->testOptionCamelCase = $testOptionCamelCase;
+    }
+
+    public function getTestOptionCamelCase()
+    {
+        return $this->testOptionCamelCase;
+    }
+
+    public function setTestoptionalllowercase($testoptionalllowercase)
+    {
+        $this->testoptionalllowercase = $testoptionalllowercase;
+    }
+
+    public function getTestoptionalllowercase()
+    {
+        return $this->testoptionalllowercase;
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+    }
+}


### PR DESCRIPTION
1.  Created `BaseFilter` class. There is `BaseFilter::setOptions()` which will call setters for each option, this method is automatically being called from constructor. It also includes `BaseFilter::isOptionSupported()` method
2.  Now all filters extend from `BaseFilter`, so all of them support `::setOptions()` and `::isOptionSupported()` methods
3.  Added test for `BaseFilter` methods and option name validation
4.  Also added bunch of missing setter methods in filters, to be able to call them through `::setOptions()`
#### Purpose of This Commit

https://github.com/widmogrod/zf2-assetic-module
As you know this project is using Assetic.

Currently the configuration file of AsseticModule looks like the following:

``` php
<?php
return array(
'assetic_configuration' => array(
    'modules' => array(
        /*
         * Application moodule - assets configuration
         */
        'application' => array(
            'root_path' => __DIR__ . '/../assets',

            'collections' => array(
                'base_css' => array(
                    'assets' => array(
                        'css/bootstrap-responsive.min.css',
                        'css/style.css',
                        'css/bootstrap.min.css',
                    ),
                    'filters' => array(
                        'CssRewriteFilter' => array(
                            'name' => 'Assetic\Filter\LessFilter',
  /* attention ==> */       'option' => array(
                                '/usr/bin/node', // first argument of constructor
                                array('/usr/local/lib/node_modules'), // second argument
                            ),
                        ),
                    ),
                    'options' => array(),
                ),
            ),
        ),
    ),
),
);
```

In my opinion it will seem more _natively-integrated_, if it will look like this:

``` php
<?php
// ...
array(
    'filters' => array(
        'CssRewriteFilter' => array(
            'name' => 'Assetic\Filter\LessFilter',
            'options' => array(
                'node_bin' => '/usr/bin/node',
                'node_path' => array('/usr/local/lib/node_modules'),
            ),
        ),
    ),
);
```

I think you will agree, this looks more _friendly_ and more _self-descriptive_

To achieve this all filters must have at least `::setOptions()` method.
#### TODO

README.md must be updated according to this commit
