### PR TITLE
Loosen up asset/filter name checks. Fix assetic #246 #255.

### DIFF
--- a/src/Assetic/AssetManager.php
+++ b/src/Assetic/AssetManager.php
@@ -62,7 +62,7 @@ class AssetManager
      */
     public function set($name, AssetInterface $asset)
     {
-        if (!ctype_alnum(str_replace('_', '', $name))) {
+        if (!ctype_alnum(str_replace(array('_', '-', '.'), '', $name))) {
             throw new \InvalidArgumentException(sprintf('The name "%s" is invalid.', $name));
         }
 

--- a/src/Assetic/FilterManager.php
+++ b/src/Assetic/FilterManager.php
@@ -57,7 +57,7 @@ class FilterManager
      */
     protected function checkName($name)
     {
-        if (!ctype_alnum(str_replace('_', '', $name))) {
+        if (!ctype_alnum(str_replace(array('_', '-', '.'), '', $name))) {
             throw new \InvalidArgumentException(sprintf('The name "%s" is invalid.', $name));
         }
     }


### PR DESCRIPTION
This allows for not only '_', but also '-' and '.' in asset/filter names. Rationale provided in #246.