### PR TITLE
Fixed error detection

### DIFF
--- a/src/Assetic/Filter/Yui/BaseCompressorFilter.php
+++ b/src/Assetic/Filter/Yui/BaseCompressorFilter.php
@@ -96,7 +96,7 @@ abstract class BaseCompressorFilter extends BaseProcessFilter
         $code = $proc->run();
         unlink($input);
 
-        if (0 !== $code) {
+        if (0 !== $code && null !== $code) {
             if (file_exists($output)) {
                 unlink($output);
             }


### PR DESCRIPTION
$code was null on success on Linux CentOS 5 with jre7
