### PR TITLE
Fixed protocol-relative css imports

### DIFF
--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -56,7 +56,7 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
             } elseif (0 === strpos($matches['url'], '//')) {
                 // protocol-relative
                 list($importHost, $importPath) = explode('/', substr($matches['url'], 2), 2);
-                $importHost = '//'.$importHost;
+                $importRoot = '//'.$importHost;
             } elseif ('/' == $matches['url'][0]) {
                 // root-relative
                 $importPath = substr($matches['url'], 1);


### PR DESCRIPTION
This fixes a mistake in the source of the CssImportFilter with protocol-relative urls. The host part of the url was lost in the process and so the import did not succeed.
