### PR TITLE
Do not check for the extension in css imports for remote urls

### DIFF
--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -71,7 +71,7 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
             }
 
             // ignore other imports
-            if ('css' != pathinfo($importPath, PATHINFO_EXTENSION)) {
+            if (!isset($importHost) && 'css' != pathinfo($importPath, PATHINFO_EXTENSION)) {
                 return $matches[0];
             }
 


### PR DESCRIPTION
There are plenty of valid urls with no explicit file extension that currently do not work because of this check.
For example the google font apis look like this:
http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700
