### PR TITLE
AssetCollection::clearFilters() does not work once the collection has been iterated

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -128,6 +128,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     public function clearFilters()
     {
         $this->filters->clear();
+        $this->clones = new \SplObjectStorage();
     }
 
     public function load(FilterInterface $additionalFilter = null)

--- a/tests/Assetic/Test/Asset/AssetCollectionTest.php
+++ b/tests/Assetic/Test/Asset/AssetCollectionTest.php
@@ -354,4 +354,22 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $coll1->getFilters());
         $this->assertCount(2, $coll2->getFilters());
     }
+
+    public function testClearingFiltersWorksAfterCollectionHasBeenIterated() {
+        $coll = new AssetCollection();
+        $coll->add(new StringAsset(""));
+        $coll->ensureFilter(new CallablesFilter());
+
+        /* This iteration is necessary to internally prime the collection's
+           "clones" with one filter. */
+        foreach ($coll as $asset) {
+            $this->assertCount(1, $asset->getFilters());
+        }
+
+        $coll->clearFilters();
+
+        foreach ($coll as $asset) {
+            $this->assertCount(0, $asset->getFilters());
+        }
+    }
 }


### PR DESCRIPTION
Found this during #427, but does not fix the problem over there. Making it a separate PR.
