### PR TITLE
AssetCollection::clearFilters() does not work once the collection has been iterated (1.1.x)

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -128,6 +128,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     public function clearFilters()
     {
         $this->filters->clear();
+        $this->clones = new \SplObjectStorage();
     }
 
     public function load(FilterInterface $additionalFilter = null)

--- a/tests/Assetic/Test/Asset/AssetCollectionTest.php
+++ b/tests/Assetic/Test/Asset/AssetCollectionTest.php
@@ -372,4 +372,22 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testClearingFiltersWorksAfterCollectionHasBeenIterated()
+    {
+        $coll = new AssetCollection();
+        $coll->add(new StringAsset(""));
+        $coll->ensureFilter(new CallablesFilter());
+
+        /* This iteration is necessary to internally prime the collection's
+           "clones" with one filter. */
+        foreach ($coll as $asset) {
+            $this->assertCount(1, $asset->getFilters());
+        }
+
+        $coll->clearFilters();
+
+        foreach ($coll as $asset) {
+            $this->assertCount(0, $asset->getFilters());
+        }
+    }
 }


### PR DESCRIPTION
Found this during #427, but does not fix the problem over there. Was #441 initially, but this is rebased to 1.1.x
