### PR TITLE
Change the DependencyExtractor interface to pass the Asset.

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -5,3 +5,5 @@
    `WorkerInterface::process()`
  * [BC BREAK] Removed `LazyAssetManager` from `CacheBustingWorker` constructor
  * A new `getSourceDirectory()` method was added on the AssetInterface
+ * [BC BREAK] Changed the DependencyExtractor interface to take the Asset, not
+   only its contents and source directory.

--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -274,7 +274,7 @@ class AssetFactory
                 }
                 $clone->load();
 
-                foreach ($filter->getChildren($this, $clone->getContent(), $clone->getSourceDirectory()) as $child) {
+                foreach ($filter->getChildren($this, $clone) as $child) {
                     $mtime = max($mtime, $this->getLastModified($child));
                 }
             }

--- a/src/Assetic/Filter/CallablesFilter.php
+++ b/src/Assetic/Filter/CallablesFilter.php
@@ -51,10 +51,10 @@ class CallablesFilter implements FilterInterface, DependencyExtractorInterface
         }
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         if (null !== $callable = $this->extractor) {
-            return $callable($factory, $content, $loadPath);
+            return $callable($factory, $asset);
         }
 
         return array();

--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -370,7 +370,7 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/CssEmbedFilter.php
+++ b/src/Assetic/Filter/CssEmbedFilter.php
@@ -134,7 +134,7 @@ class CssEmbedFilter extends BaseProcessFilter implements DependencyExtractorInt
         $asset->setContent($proc->getOutput());
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -100,7 +100,7 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/DependencyExtractorInterface.php
+++ b/src/Assetic/Filter/DependencyExtractorInterface.php
@@ -24,11 +24,10 @@ interface DependencyExtractorInterface extends FilterInterface
     /**
      * Returns child assets.
      *
-     * @param AssetFactory $factory  The asset factory
-     * @param string       $content  The asset content
-     * @param string       $loadPath An optional load path
+     * @param AssetFactory   $factory The asset factory
+     * @param AssetInterface $asset   The asset to extract dependencies from
      *
      * @return AssetInterface[] Child assets
      */
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null);
+    public function getChildren(AssetFactory $factory, AssetInterface $asset);
 }

--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -161,11 +161,11 @@ EOF;
      * @todo support for import-once
      * @todo support for import (less) "lib.css"
      */
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         $loadPaths = $this->loadPaths;
-        if (null !== $loadPath) {
-            $loadPaths[] = $loadPath;
+        if ($dir = $asset->getSourceDirectory()) {
+            $loadPaths[] = $dir;
         }
 
         if (empty($loadPaths)) {
@@ -173,7 +173,7 @@ EOF;
         }
 
         $children = array();
-        foreach (LessUtils::extractImports($content) as $reference) {
+        foreach (LessUtils::extractImports($asset->getContent()) as $reference) {
             if ('.css' === substr($reference, -4)) {
                 // skip normal css imports
                 // todo: skip imports with media queries

--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -105,11 +105,11 @@ class LessphpFilter implements DependencyExtractorInterface
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         $loadPaths = $this->loadPaths;
-        if (null !== $loadPath) {
-            $loadPaths[] = $loadPath;
+        if ($dir = $asset->getSourceDirectory()) {
+            $loadPaths[] = $dir;
         }
 
         if (empty($loadPaths)) {
@@ -117,7 +117,7 @@ class LessphpFilter implements DependencyExtractorInterface
         }
 
         $children = array();
-        foreach (LessUtils::extractImports($content) as $reference) {
+        foreach (LessUtils::extractImports($asset->getContent()) as $reference) {
             if ('.css' === substr($reference, -4)) {
                 // skip normal css imports
                 // todo: skip imports with media queries

--- a/src/Assetic/Filter/PhpCssEmbedFilter.php
+++ b/src/Assetic/Filter/PhpCssEmbedFilter.php
@@ -44,7 +44,7 @@ class PhpCssEmbedFilter implements DependencyExtractorInterface
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/RooleFilter.php
+++ b/src/Assetic/Filter/RooleFilter.php
@@ -65,7 +65,7 @@ class RooleFilter extends BaseNodeFilter implements DependencyExtractorInterface
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -178,11 +178,11 @@ class SassFilter extends BaseProcessFilter implements DependencyExtractorInterfa
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         $loadPaths = $this->loadPaths;
-        if ($loadPath) {
-            array_unshift($loadPaths, $loadPath);
+        if ($dir = $asset->getSourceDirectory()) {
+            array_unshift($loadPaths, $dir);
         }
 
         if (!$loadPaths) {
@@ -190,7 +190,7 @@ class SassFilter extends BaseProcessFilter implements DependencyExtractorInterfa
         }
 
         $children = array();
-        foreach (CssUtils::extractImports($content) as $reference) {
+        foreach (CssUtils::extractImports($asset->getContent()) as $reference) {
             if ('.css' === substr($reference, -4)) {
                 // skip normal css imports
                 // todo: skip imports with media queries
@@ -214,7 +214,8 @@ class SassFilter extends BaseProcessFilter implements DependencyExtractorInterfa
 
             foreach ($loadPaths as $loadPath) {
                 foreach ($needles as $needle) {
-                    if (file_exists($file = $loadPath.'/'.$needle)) {
+                    $file = $loadPath.'/'.$needle;
+                    if (file_exists($file)) {
                         $coll = $factory->createAsset($file, array(), array('root' => $loadPath));
                         foreach ($coll as $leaf) {
                             $leaf->ensureFilter($this);

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -69,7 +69,7 @@ class ScssphpFilter implements DependencyExtractorInterface
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/SprocketsFilter.php
+++ b/src/Assetic/Filter/SprocketsFilter.php
@@ -123,7 +123,7 @@ EOF;
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/src/Assetic/Filter/StylusFilter.php
+++ b/src/Assetic/Filter/StylusFilter.php
@@ -117,7 +117,7 @@ EOF;
     {
     }
 
-    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    public function getChildren(AssetFactory $factory, AssetInterface $asset)
     {
         // todo
         return array();

--- a/tests/Assetic/Test/Filter/CallablesFilterTest.php
+++ b/tests/Assetic/Test/Filter/CallablesFilterTest.php
@@ -11,6 +11,7 @@
 
 namespace Assetic\Test\Filter;
 
+use Assetic\Asset\AssetInterface;
 use Assetic\Asset\StringAsset;
 use Assetic\Filter\CallablesFilter;
 use Assetic\Factory\AssetFactory;
@@ -40,30 +41,38 @@ class CallablesFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $nb, '->filterDump() calls the loader callable');
     }
 
+    public function testMissingDependencyExtractor()
+    {
+        $assetFactoryMock = $this->getMockBuilder('Assetic\\Factory\\AssetFactory')
+                    ->disableOriginalConstructor()
+                    ->getMock();
+
+        $asset = new StringAsset("foo");
+
+        $filter = new CallablesFilter();
+        $this->assertEquals(array(), $filter->getChildren($assetFactoryMock, $asset), '-> without an extractor callable, the filter just returns an empty array (of assets)');
+    }
+
     public function testDependencyExtractor()
     {
-
         $nb = 0;
         $self = $this;
         $assetFactoryMock = $this->getMockBuilder('Assetic\\Factory\\AssetFactory')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $result = array(new StringAsset("test"));
+        $asset = new StringAsset("test");
+        $result = array($asset);
 
-        $filter = new CallablesFilter(null, null, function(AssetFactory $factory, $content, $loadPath) use (&$nb, $assetFactoryMock, $self, $result) {
-            $self->assertSame($factory, $assetFactoryMock, '-> the asset factory is passed to the callable');
-            $self->assertEquals('content', $content, '-> the content is passed to the callable');
-            $self->assertEquals('loadPath', $loadPath, '-> the load path is passed to the callable');
+        $filter = new CallablesFilter(null, null, function(AssetFactory $factory, AssetInterface $passedAsset) use ($self, &$nb, $assetFactoryMock, $asset, $result) {
+            $self->assertSame($assetFactoryMock, $factory, '-> the asset factory is passed to the callable');
+            $self->assertSame($asset, $passedAsset, '-> the asset is passed to the callable');
             $nb++;
             return $result;
         });
 
-        $r = $filter->getChildren($assetFactoryMock, 'content', 'loadPath');
+        $r = $filter->getChildren($assetFactoryMock, $asset);
         $this->assertEquals($result, $r, "->getChildren() returns the callable's result");
         $this->assertEquals(1, $nb, '->getChildren() calls the extractor callable');
-
-        $filter = new CallablesFilter();
-        $this->assertEquals(array(), $filter->getChildren($assetFactoryMock, 'ignored', 'ignored'), '-> without an extractor callable, the filter just returns an empty array (of assets)');
     }
 }

--- a/tests/Assetic/Test/Filter/LessFilterTest.php
+++ b/tests/Assetic/Test/Filter/LessFilterTest.php
@@ -140,10 +140,15 @@ EOF;
      */
     public function testGetChildren($import)
     {
-        $children = $this->filter->getChildren(new AssetFactory('/'), $import, __DIR__.'/fixtures/less');
+        $factory = new AssetFactory('/');
+        $asset = new StringAsset($import, array(), __DIR__ . "/fixtures/less", "test.less");
+        $asset->load(); // https://github.com/kriswallsmith/assetic/pull/432#issuecomment-18355754
+
+        $children = $this->filter->getChildren($factory, $asset);
 
         $this->assertCount(1, $children);
         $this->assertEquals('main.less', $children[0]->getSourcePath());
+        $this->assertEquals($asset->getSourceDirectory(), $children[0]->getSourceDirectory());
     }
 
     public function provideImports()

--- a/tests/Assetic/Test/Filter/LessphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/LessphpFilterTest.php
@@ -182,10 +182,15 @@ EOF;
      */
     public function testGetChildren($import)
     {
-        $children = $this->filter->getChildren(new AssetFactory('/'), $import, __DIR__.'/fixtures/less');
+        $factory = new AssetFactory("/");
+        $asset = new StringAsset($import, array(), __DIR__ . "/fixtures/less", "test.less");
+        $asset->load(); // https://github.com/kriswallsmith/assetic/pull/432#issuecomment-18355754
+
+        $children = $this->filter->getChildren($factory, $asset);
 
         $this->assertCount(1, $children);
         $this->assertEquals('main.less', $children[0]->getSourcePath());
+        $this->assertEquals($asset->getSourceDirectory(), $children[0]->getSourceDirectory());
     }
 
     public function provideImports()

--- a/tests/Assetic/Test/Filter/Sass/SassFilterTest.php
+++ b/tests/Assetic/Test/Filter/Sass/SassFilterTest.php
@@ -83,10 +83,12 @@ EOF;
     public function testGetChildrenCatchesSassImports()
     {
         $factory = new AssetFactory('/'); // the factory root isn't used
+        $asset = new StringAsset('@import "include";', array(), __DIR__ . "/../fixtures/sass", "test.scss");
+        $asset->load(); // https://github.com/kriswallsmith/assetic/pull/432#issuecomment-18355754
 
-        $children = $this->filter->getChildren($factory, '@import "include";', __DIR__.'/../fixtures/sass');
+        $children = $this->filter->getChildren($factory, $asset);
         $this->assertCount(1, $children);
-        $this->assertEquals(__DIR__.'/../fixtures/sass', $children[0]->getSourceRoot());
+        $this->assertEquals($asset->getSourceDirectory(), $children[0]->getSourceDirectory());
         $this->assertEquals('_include.scss', $children[0]->getSourcePath());
 
         $filters = $children[0]->getFilters();
@@ -105,7 +107,9 @@ EOF;
 CSS;
 
         $factory = new AssetFactory('/'); // the factory root isn't used
+        $asset = new StringAsset($imports, array(), __DIR__, '/../fixtures/sass');
+        $asset->load(); // https://github.com/kriswallsmith/assetic/pull/432#issuecomment-18355754
 
-        $this->assertEquals(array(), $this->filter->getChildren($factory, $imports, __DIR__.'/../fixtures/sass'));
+        $this->assertEmpty($this->filter->getChildren($factory, $asset));
     }
 }


### PR DESCRIPTION
It's a BC break, but that way it's more expressive, concise and powerful as
the whole asset is available, not only two aspects pulled out of it.

Tests probably gonna fail for the moment as a lot of tests are skipped locally for me.
