### PR TITLE
by reversing the order in which the import paths are added, you can actu...

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -45,11 +45,11 @@ class ScssphpFilter implements DependencyExtractorInterface
         if ($this->compass) {
             new \scss_compass($lc);
         }
-        if ($dir = $asset->getSourceDirectory()) {
-            $lc->addImportPath($dir);
-        }
         foreach ($this->importPaths as $path) {
             $lc->addImportPath($path);
+        }
+        if ($dir = $asset->getSourceDirectory()) {
+            $lc->addImportPath($dir);
         }
 
         $asset->setContent($lc->compile($asset->getContent()));


### PR DESCRIPTION
...ally override default import files in, for example, other bundles
