### PR TITLE
Do not dump assets when not changed

### DIFF
--- a/src/Assetic/AssetWriter.php
+++ b/src/Assetic/AssetWriter.php
@@ -22,8 +22,8 @@ use Assetic\Util\VarUtils;
  */
 class AssetWriter
 {
-    private $dir;
-    private $values;
+    protected $dir;
+    protected $values;
 
     /**
      * Constructor.
@@ -59,18 +59,14 @@ class AssetWriter
         foreach (VarUtils::getCombinations($asset->getVars(), $this->values) as $combination) {
             $asset->setValues($combination);
 
-            $target = $this->dir.'/'.VarUtils::resolve(
-                $asset->getTargetPath(),
-                $asset->getVars(),
-                $asset->getValues()
+            static::write(
+                $this->dir.'/'.VarUtils::resolve(
+                    $asset->getTargetPath(),
+                    $asset->getVars(),
+                    $asset->getValues()
+                ),
+                $asset->dump()
             );
-
-            if (!file_exists($target) || filemtime($target) < $asset->getLastModified()) {
-                static::write(
-                    $target,
-                    $asset->dump()
-                );
-            }
         }
     }
 

--- a/src/Assetic/AssetWriter.php
+++ b/src/Assetic/AssetWriter.php
@@ -59,14 +59,18 @@ class AssetWriter
         foreach (VarUtils::getCombinations($asset->getVars(), $this->values) as $combination) {
             $asset->setValues($combination);
 
-            static::write(
-                $this->dir.'/'.VarUtils::resolve(
-                    $asset->getTargetPath(),
-                    $asset->getVars(),
-                    $asset->getValues()
-                ),
-                $asset->dump()
+            $target = $this->dir.'/'.VarUtils::resolve(
+                $asset->getTargetPath(),
+                $asset->getVars(),
+                $asset->getValues()
             );
+
+            if (!file_exists($target) || filemtime($target) < $asset->getLastModified()) {
+                static::write(
+                    $target,
+                    $asset->dump()
+                );
+            }
         }
     }
 

--- a/src/Assetic/NonOverwritingAssetWriter.php
+++ b/src/Assetic/NonOverwritingAssetWriter.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic;
+
+use Assetic\Asset\AssetInterface;
+use Assetic\Util\VarUtils;
+
+/**
+ * Writes assets to the filesystem only when an asset is outdated.
+ *
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class NonOverwritingAssetWriter extends AssetWriter
+{
+    public function writeAsset(AssetInterface $asset)
+    {
+        foreach (VarUtils::getCombinations($asset->getVars(), $this->values) as $combination) {
+            $asset->setValues($combination);
+
+            $target = $this->dir.'/'.VarUtils::resolve(
+                $asset->getTargetPath(),
+                $asset->getVars(),
+                $asset->getValues()
+            );
+
+            if (!file_exists($target) || filemtime($target) < $asset->getLastModified()) {
+                static::write(
+                    $target,
+                    $asset->dump()
+                );
+            }
+        }
+    }
+}

--- a/tests/Assetic/Test/NonOverwritingAssetWriterTest.php
+++ b/tests/Assetic/Test/NonOverwritingAssetWriterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test;
+
+use Assetic\Asset\FileAsset;
+
+use Assetic\AssetManager;
+use Assetic\NonOverwritingAssetWriter;
+
+class NonOverwritingAssetWriterTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->dir = sys_get_temp_dir().'/assetic_tests_'.rand(11111, 99999);
+        mkdir($this->dir);
+        $this->writer = new NonOverwritingAssetWriter($this->dir, array(
+            'locale' => array('en', 'de', 'fr'),
+            'browser' => array('ie', 'firefox', 'other'),
+            'gzip' => array('gzip', '')
+        ));
+    }
+
+    protected function tearDown()
+    {
+        array_map('unlink', glob($this->dir.'/*'));
+        rmdir($this->dir);
+    }
+
+    public function testWritesWhenNonExistend()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $am = $this->getMock('Assetic\\AssetManager');
+
+        $am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array('foo')));
+        $am->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($asset));
+        $asset->expects($this->atLeastOnce())
+            ->method('getTargetPath')
+            ->will($this->returnValue('target_url'));
+        $asset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue('content'));
+        $asset->expects($this->atLeastOnce())
+            ->method('getVars')
+            ->will($this->returnValue(array()));
+        $asset->expects($this->atLeastOnce())
+            ->method('getValues')
+            ->will($this->returnValue(array()));
+
+        $this->writer->writeManagerAssets($am);
+
+        $this->assertFileExists($this->dir.'/target_url');
+        $this->assertEquals('content', file_get_contents($this->dir.'/target_url'));
+    }
+
+    public function testNotWritesWhenNotModified()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $am = $this->getMock('Assetic\\AssetManager');
+
+        $am->expects($this->exactly(2))
+            ->method('getNames')
+            ->will($this->returnValue(array('foo')));
+        $am->expects($this->exactly(2))
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($asset));
+        $asset->expects($this->atLeastOnce())
+            ->method('getTargetPath')
+            ->will($this->returnValue('target_url'));
+        $asset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue('content'));
+        $asset->expects($this->atLeastOnce())
+            ->method('getVars')
+            ->will($this->returnValue(array()));
+        $asset->expects($this->atLeastOnce())
+            ->method('getValues')
+            ->will($this->returnValue(array()));
+
+        $this->writer->writeManagerAssets($am);
+        
+        $this->assertFileExists($this->dir.'/target_url');
+        $mtime = filemtime($this->dir.'/target_url');
+        
+        sleep(1);
+        
+        $this->writer->writeManagerAssets($am);
+        $this->assertFileExists($this->dir.'/target_url');
+        $this->assertEquals($mtime, filemtime($this->dir.'/target_url'));
+    }
+}


### PR DESCRIPTION
Assets are copied on every request, which induces a great performance penalty. This PR makes sure that assets are only dumped when they do not exist or when they are modified.

Fixes https://github.com/widmogrod/zf2-assetic-module/issues/74
