### PR TITLE
Help with writer needs asset target path

### DIFF
--- a/docs/en/define.md
+++ b/docs/en/define.md
@@ -142,4 +142,8 @@ create the files your templates are going to be referencing.
 
 After running this script, all of the assets in your asset manager will be
 loaded into memory, filtered with their configured filters and dumped to your
-web directory as static files, ready to be served.
+web directory as static files, ready to be served. Just remember to give each
+asset the path to where it should be dumped to.
+
+    $asset = new FileAsset('/path/to/jquery.js');
+    $asset->setTargetPath('jquery.js');

--- a/src/Assetic/AssetWriter.php
+++ b/src/Assetic/AssetWriter.php
@@ -59,6 +59,12 @@ class AssetWriter
         foreach (VarUtils::getCombinations($asset->getVars(), $this->values) as $combination) {
             $asset->setValues($combination);
 
+            if (is_null($asset->getTargetPath())) {
+                throw new \RuntimeException(
+                    'Asset targetPath has not been set'
+                );
+            }
+            
             static::write(
                 $this->dir.'/'.VarUtils::resolve(
                     $asset->getTargetPath(),

--- a/src/Assetic/AssetWriter.php
+++ b/src/Assetic/AssetWriter.php
@@ -56,15 +56,15 @@ class AssetWriter
 
     public function writeAsset(AssetInterface $asset)
     {
+        if (null === $asset->getTargetPath()) {
+            throw new \RuntimeException(
+                'Asset targetPath has not been set'
+            );
+        }
+            
         foreach (VarUtils::getCombinations($asset->getVars(), $this->values) as $combination) {
             $asset->setValues($combination);
 
-            if (is_null($asset->getTargetPath())) {
-                throw new \RuntimeException(
-                    'Asset targetPath has not been set'
-                );
-            }
-            
             static::write(
                 $this->dir.'/'.VarUtils::resolve(
                     $asset->getTargetPath(),

--- a/tests/Assetic/Test/AssetWriterTest.php
+++ b/tests/Assetic/Test/AssetWriterTest.php
@@ -129,4 +129,23 @@ class AssetWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('var messages = {"text.greet": "All\u00f4 %name%!"};',
             file_get_contents($this->dir.'/messages.fr.js'));
     }
+
+    /**
+     * @expectedException        RuntimeException
+     * @expectedExceptionMessage Asset targetPath has not been set
+     */
+    public function testWriteAssetRequiresNonNullTargetPath()
+    {
+        $asset = $this->getMock('Assetic\Asset\AssetInterface');
+
+        $asset->expects($this->atLeastOnce())
+            ->method('getTargetPath')
+            ->will($this->returnValue(null));
+        $asset->expects($this->atLeastOnce())
+            ->method('getVars')
+            ->will($this->returnValue(array()));
+
+        $this->writer->writeAsset($asset);
+    }
+
 }

--- a/tests/Assetic/Test/AssetWriterTest.php
+++ b/tests/Assetic/Test/AssetWriterTest.php
@@ -141,9 +141,6 @@ class AssetWriterTest extends \PHPUnit_Framework_TestCase
         $asset->expects($this->atLeastOnce())
             ->method('getTargetPath')
             ->will($this->returnValue(null));
-        $asset->expects($this->atLeastOnce())
-            ->method('getVars')
-            ->will($this->returnValue(array()));
 
         $this->writer->writeAsset($asset);
     }


### PR DESCRIPTION
I took some time to understand that AssetWriter breaks if assets are not given explicitly a targetPath. I thought Assetic would deduce that from either AssetManager's name or Asset's source. As it is, trying by copy&paste from documentation's example will lead to errors and I'm not the first one being caught by this (http://stackoverflow.com/questions/14538335/assetic-unable-to-write-assets).

So I made it return a meaningful error and updated documentation.

Thank you
Federico
