### PR TITLE
[CompassFilter] Fix empty ProcessBuilder arguments

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -310,7 +310,7 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
             $pb->add('--config')->add($configFile);
         }
 
-        $pb->add('--sass-dir')->add('')->add('--css-dir')->add('');
+        $pb->add('--sass-dir')->add('.')->add('--css-dir')->add('.');
 
         // compass choose the type (sass or scss from the filename)
         if (null !== $this->scss) {


### PR DESCRIPTION
When passing `--sass-dir` and `--css-dir` options to the compass binary, the filter uses empty arguments.

But using empty arguments on windows seems to screw the way arguments are passed to the binary (In the resulting command line, they are translated into `""` by the process builder, and those arguments seems to be purely ignored by the shell), therefore the following arguments are concatenated.

This leads compass to raise a `You must compile individual stylesheets from the project directory.` error.

Adding a `'.'` instead of just `''` fixes this issue on Windows 7 Pro using Compass 0.12.2 (Alnilam).
