### PR TITLE
Added ability to set the sprite load path in the Compass Filter

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -52,6 +52,7 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
     private $httpGeneratedImagesPath;
     private $generatedImagesPath;
     private $httpJavascriptsPath;
+    private $spriteLoadPath;
     private $homeEnv = true;
 
     public function __construct($compassPath = '/usr/bin/compass', $rubyPath = null)
@@ -183,6 +184,11 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
         $this->httpJavascriptsPath = $httpJavascriptsPath;
     }
 
+    public function setSpriteLoadPath($spriteLoadPath)
+    {
+        $this->spriteLoadPath = $spriteLoadPath;
+    }
+
     public function setHomeEnv($homeEnv)
     {
         $this->homeEnv = $homeEnv;
@@ -285,6 +291,10 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
 
         if ($this->httpJavascriptsPath) {
             $optionsConfig['http_javascripts_path'] = $this->httpJavascriptsPath;
+        }
+
+        if ($this->spriteLoadPath) {
+            $optionsConfig['sprite_load_path'] = $this->spriteLoadPath;
         }
 
         if ($this->fontsDir) {


### PR DESCRIPTION
There is another issue ongoing which would remove the requirement for this PR (https://github.com/kriswallsmith/assetic/pull/314) - but until that issue has been further discussed this configuration option lets you set the sprite_load_path and image_dir independently.

There are multiple issues and questions arising about sprite_paths and with this config option I have a pretty decent solution which answers most questions I've seen. I'd be able to document this in the SF2 cookbook once the PR is merged.
