### PR TITLE
Check for a valid file created from tempnam()

### DIFF
--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -32,6 +32,23 @@ abstract class BaseProcessFilter implements FilterInterface
     }
 
     /**
+     * Creates a new temporary file.
+     *
+     * @throws FilterException
+     * @return resource The temporary file resource handle.
+     */
+    protected function createTempFile()
+    {
+        $tmpHandle = tmpfile();
+
+        if (false === $tmpHandle) {
+            throw new FilterException('Error creating temp file.');
+        }
+
+        return $tmpHandle;
+    }
+
+    /**
      * Creates a new process builder.
      *
      * @param array $arguments An optional array of arguments

--- a/src/Assetic/Filter/UglifyCssFilter.php
+++ b/src/Assetic/Filter/UglifyCssFilter.php
@@ -97,18 +97,14 @@ class UglifyCssFilter extends BaseNodeFilter
         }
 
         // input and output files
-        $input = tempnam(sys_get_temp_dir(), 'input');
-        
-        if (false === $input) {
-            throw new \RuntimeException('Could not create temp file. Check temp directory permissions.');
-        }
+        $input = $this->createTempFile();
 
-        file_put_contents($input, $asset->getContent());
-        $pb->add($input);
+        fwrite($input, $asset->getContent());
+        $pb->add(stream_get_meta_data($input)['uri']);
 
         $proc = $pb->getProcess();
         $code = $proc->run();
-        unlink($input);
+        fclose($input);
 
         if (127 === $code) {
             throw new \RuntimeException('Path to node executable could not be resolved.');


### PR DESCRIPTION
I was getting a weird "file not found" error from the uglifycss filter. After searching through the code, I found that my tempdir was not writeable by PHP due to a permissions problem. tempnam() returns false when a file could not be created for writing as in this scenario. If the error is not caught, the uglifycss command runs with a missing argument (the filename). Suggesting a simple exception to help troubleshooting.
