### PR TITLE
CompassFilter: allow require specific compass plugin versions

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -298,6 +298,10 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
         if (count($optionsConfig)) {
             $config = array();
             foreach ($this->plugins as $plugin) {
+                if(is_array($plugin)) { // version check
+                    $config[] = sprintf("gem '%s'", addcslashes(implode("', '", $plugin), '\\'));
+                    $plugin = $plugin[0];
+                }
                 $config[] = sprintf("require '%s'", addcslashes($plugin, '\\'));
             }
             foreach ($optionsConfig as $name => $value) {


### PR DESCRIPTION
You could easily define compass plugin version requirements as: 

[['zurb-foundation', '~>3.2.5'], 'bootstrap-sass']