### PR TITLE
fix for compass filter

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -310,7 +310,7 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
             $pb->add('--config')->add($configFile);
         }
 
-        $pb->add('--sass-dir')->add('')->add('--css-dir')->add('');
+        $pb->add('--sass-dir')->add($tempDir)->add('--css-dir')->add($tempDir);
 
         // compass choose the type (sass or scss from the filename)
         if (null !== $this->scss) {


### PR DESCRIPTION
Fix for exception in windows environment

 [Assetic\Exception\FilterException]  
  An error occurred while running:  
  "C:/Ruby200-x64/bin/ruby.exe" "C:/Ruby200-x64/bin/compass" "compile" "C:\Us  
  ers\Developer\AppData\Local\Temp" "--config" "C:\Users\Developer\AppData\Local\  
  Temp\assB843.tmp" "--sass-dir"  "--css-dir"  "C:/Users/Developer/AppData/Loca  
  l/Temp/assB844.tmp.scss"                                                     

  Error Output:  
  You must compile individual stylesheets from the project directory.
