### PR TITLE
Allow compass project directory to be set.

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -333,7 +333,7 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
             $type = 'scss';
         }
 
-        $tempName = tempnam($tempDir, 'assetic_compass');
+        $tempName = tempnam($projectDir, 'assetic_compass');
         unlink($tempName); // FIXME: don't use tempnam() here
 
         // input


### PR DESCRIPTION
This adds support for path/to/project when using `compass compile`. When
compass generates sprites, it puts them into the project path. Assetic
configuration can now specify the location where those sprites are
created.
