### PR TITLE
Optimize Closure jar compilation

### DIFF
--- a/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
@@ -42,7 +42,7 @@ class CompilerJarFilter extends BaseCompilerFilter
             $is64bit
                 ? array('-server', '-XX:+TieredCompilation')
                 : array('-client', '-d32'),
-            array('-jar', $this->jarPath),
+            array('-jar', $this->jarPath)
         ));
 
         if (null !== $this->timeout) {


### PR DESCRIPTION
As noted in the [Closure FAQ](https://code.google.com/p/closure-compiler/wiki/FAQ#What_are_the_recommended_Java_VM_command-line_options?) (and discussed [here](https://plus.google.com/104744871076396904202/posts/CEwkCSQzLfr) and [here](https://groups.google.com/forum/#!topic/closure-compiler-discuss/Xsdx7m0gQnQ)), there are some recommended flags to java that speed up Closure compilation, often quite significantly.

I've only tested the 64-bit flags (and only on Linux) as I don't currently have a 32-bit system set up.  The other reservation I would have is that the test for 32- vs 64-bit tests PHP and assumes the java binary will be the same.
