### PR TITLE
Allow to set encoding config for compass filter.

### DIFF
--- a/src/Assetic/Filter/CompassFilter.php
+++ b/src/Assetic/Filter/CompassFilter.php
@@ -46,6 +46,8 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
     // compass configuration file options
     private $plugins = array();
     private $loadPaths = array();
+    private $defaultEncoding;
+    private $externalEncoding;
     private $httpPath;
     private $httpImagesPath;
     private $httpFontsPath;
@@ -151,6 +153,16 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
     public function addLoadPath($loadPath)
     {
         $this->loadPaths[] = $loadPath;
+    }
+
+    public function setDefaultEncoding($defaultEncoding)
+    {
+        $this->defaultEncoding = $defaultEncoding;
+    }
+
+    public function setExternalEncoding($externalEncoding)
+    {
+        $this->externalEncoding = $externalEncoding;
     }
 
     public function setHttpPath($httpPath)
@@ -261,6 +273,14 @@ class CompassFilter extends BaseProcessFilter implements DependencyExtractorInte
 
         if ($this->noCache) {
             $optionsConfig['sass_options']['no_cache'] = true;
+        }
+
+        if ($this->defaultEncoding) {
+            $optionsConfig['encoding'] = $this->defaultEncoding;
+        }
+
+        if ($this->externalEncoding) {
+            $optionsConfig['Encoding.default_external'] = $this->externalEncoding;
         }
 
         if ($this->httpPath) {


### PR DESCRIPTION
This allow to set the default and external encoding for compass filter. That help to fix encoding issues ([like this](https://github.com/chriseppstein/compass/issues/377)).
Even it is solvable by addin `@charset "utf-8"` I don't wan't to modify third party libraries that rely on `encoding = "utf-8"` or `Encoding.default_external = "utf-8"` in the config.rb.
