### PR TITLE
fixed LessUtils::filterCommentless() did not respect less-comments

### DIFF
--- a/src/Assetic/Util/LessUtils.php
+++ b/src/Assetic/Util/LessUtils.php
@@ -20,4 +20,5 @@ abstract class LessUtils extends CssUtils
 {
     const REGEX_IMPORTS         = '/@import(?:-once)? (?:url\()?(\'|"|)(?P<url>[^\'"\)\n\r]*)\1\)?;?/';
     const REGEX_IMPORTS_NO_URLS = '/@import(?:-once)? (?!url\()(\'|"|)(?P<url>[^\'"\)\n\r]*)\1;?/';
+    const REGEX_COMMENTS        = '/((?:\/\*[^*]*\*+(?:[^\/][^*]*\*+)*\/)|\/\/[^\n]+)/';
 }

--- a/tests/Assetic/Test/Util/LessUtilsTest.php
+++ b/tests/Assetic/Test/Util/LessUtilsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Util;
+
+use Assetic\Util\LessUtils;
+
+class LessUtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFilterUrls()
+    {
+        $content = 'body { background: url(../images/bg.gif); }';
+
+        $matches = array();
+        $actual = LessUtils::filterUrls($content, function($match) use(& $matches) {
+            $matches[] = $match['url'];
+        });
+
+        $this->assertEquals(array('../images/bg.gif'), $matches);
+    }
+
+    public function testExtractImports()
+    {
+        // These don't work yet (todo):
+        // @import url("fineprint.css") print;
+        // @import url("bluish.css") projection, tv;
+        // @import url('landscape.css') screen and (orientation:landscape);
+
+        $content = <<<CSS
+@import 'custom.css';
+@import "common.css" screen, projection;
+body { background: url(../images/bg.gif); }
+CSS;
+
+        $expected = array('common.css', 'custom.css');
+        $actual = LessUtils::extractImports($content);
+
+        $this->assertEquals($expected, array_intersect($expected, $actual), '::extractImports() returns all expected URLs');
+        $this->assertEquals(array(), array_diff($actual, $expected), '::extractImports() does not return unexpected URLs');
+    }
+
+    public function testFilterCommentless()
+    {
+        $content = 'A/*B*/C/*D*/E';
+
+        $filtered = '';
+        $result = LessUtils::filterCommentless($content, function($part) use(& $filtered) {
+            $filtered .= $part;
+            return $part;
+        });
+
+        $this->assertEquals('ACE', $filtered);
+        $this->assertEquals($content, $result);
+    }
+
+    public function testFilterCommentlessLess()
+    {
+        $content = "ACE // foo /* bar */\nbla";
+
+        $filtered = '';
+        $result = LessUtils::filterCommentless($content, function($part) use(& $filtered) {
+            $filtered .= $part;
+            return $part;
+        });
+
+        $this->assertEquals("ACE \nbla", $filtered);
+        $this->assertEquals($content, $result);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #513 |

``` css
// import (file.less)
```

Was not properly parsed, this fixes it.
