### PR TITLE
Added a compilable asset collection.

### DIFF
--- a/src/Assetic/Asset/CompilableAssetCollection.php
+++ b/src/Assetic/Asset/CompilableAssetCollection.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2013 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Assetic\Asset;
 
 use Assetic\Filter\FilterInterface;
@@ -12,8 +21,7 @@ use Assetic\Filter\FilterInterface;
  *
  * @author Grégory PLANCHAT <g.planchat@gmail.com>
  */
-class CompilableAssetCollection
-    extends AssetCollection
+class CompilableAssetCollection extends AssetCollection
 {
     public function dump(FilterInterface $additionalFilter = null)
     {


### PR DESCRIPTION
This asset collection is useful for global minification and/or global compilation (tools like sweet.js), the filters are not transferred to child nodes.

This pull request is related to pull request #516

``` php

$filter = new SweetJs\CompilerDumpFilter();

$asset = new CompilableAssetCollection();

// Adding sweet.js macros
$asset->add(new FileAsset('my/sweetjs/macros.js'));

// Adding enhanced javascript files
$asset->add(new FileAsset('my/enhanced/script.js'));

echo $asset->dump($filter);
```
