### PR TITLE
don't rely on php being in the path

### DIFF
--- a/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
+++ b/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
@@ -108,12 +108,10 @@ abstract class BasePhpFormulaLoader implements FormulaLoaderInterface
             $call,
             'echo serialize($_call);',
         )));
-        if (defined('PHP_BINARY')) {
-            $binary = PHP_BINARY;
-        } else {
-            $binary = 'php';
+        $args = unserialize(shell_exec('php '.escapeshellarg($tmp)));
+        if (!$args && defined('PHP_BINARY')) {
+            $args = unserialize(shell_exec(PHP_BINARY.' '.escapeshellarg($tmp)));
         }
-        $args = unserialize(shell_exec($binary.' '.escapeshellarg($tmp)));
         unlink($tmp);
 
         $inputs  = isset($args[0]) ? self::argumentToArray($args[0]) : array();


### PR DESCRIPTION
Since we are already in a php scripts, we are guaranteed that there is a php binary on the system, so just use the constant of the currently running execution engine.

(This came up when trying to run your tests on HHVM).
