### PR TITLE
Fix incomplete test for scssphp

### DIFF
--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -64,8 +64,6 @@ EOF;
 
     public function testCompassExtension()
     {
-        $this->markTestIncomplete('Someone fix this, SVP? (Undefined mixin "box-shadow")');
-
         $expected = <<<EOF
 .shadow {
   -webkit-box-shadow : 10px 10px 8px red;
@@ -82,6 +80,8 @@ EOF;
 
         $asset = new FileAsset(__DIR__.'/fixtures/sass/main_compass.scss');
         $asset->load();
+
+        $this->setExpectedException('Exception');
 
         $this->getFilter(false)->filterLoad($asset);
         $this->assertEquals("@import \"compass\";\n", $asset->getContent(), 'compass plugin can be disabled');


### PR DESCRIPTION
Fix the incomplete test for scssphp

The issue with 'Undefined mixin "box-shadow"', is that the compass filter is disabled.
So when importing compass, the libraries can't be loaded and the box-shadow mixin does not exist (which means the exception is expected).

There are a couple of other ways to get around this, but marking the Exception as expected seemed like the most obvious fix
