### PR TITLE
Fix correct extension when using image with vars

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -210,24 +210,24 @@ class AssetFactory
         }
 
         // append variables
+        $varsToAdd = array();
         if (!empty($options['vars'])) {
-            $toAdd = array();
             foreach ($options['vars'] as $var) {
                 if (false !== strpos($options['output'], '{'.$var.'}')) {
                     continue;
                 }
 
-                $toAdd[] = '{'.$var.'}';
-            }
-
-            if ($toAdd) {
-                $options['output'] = str_replace('*', '*.'.implode('.', $toAdd), $options['output']);
+                $varsToAdd[] = '{'.$var.'}';
             }
         }
 
         // append consensus extension if missing
         if (1 == count($extensions) && !pathinfo($options['output'], PATHINFO_EXTENSION) && $extension = key($extensions)) {
             $options['output'] .= '.'.$extension;
+        }
+
+        if ($varsToAdd) {
+            $options['output'] = str_replace('*', '*.'.implode('.', $varsToAdd), $options['output']);
         }
 
         // output --> target url

--- a/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
+++ b/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
@@ -219,6 +219,17 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("js/7d0828c.a.b_variable_input._2.js", (string) $xml->url[1]);
     }
 
+    public function testVariablesImages()
+    {
+        $this->valueSupplier->expects($this->once())
+            ->method('getValues')
+            ->will($this->returnValue(array('foo' => 'a', 'bar' => 'b')));
+
+        $xml = $this->renderXml('variables_images.twig');
+        $this->assertEquals(1, $xml->url->count());
+        $this->assertEquals("images/84f96e1.a.b_variable_input._1.jpg", (string) $xml->url[0]);
+    }
+
     public function testMultipleSameVariableValues()
     {
         $vars = array('locale');

--- a/tests/Assetic/Test/Extension/Twig/templates/variables_images.twig
+++ b/tests/Assetic/Test/Extension/Twig/templates/variables_images.twig
@@ -1,0 +1,5 @@
+<assets>
+    {% image "variable_input.{foo}.jpg" vars=["foo", "bar"] debug=true %}
+    <url>{{ asset_url }}</url>
+    {% endimage %}
+</assets>


### PR DESCRIPTION
This should fix #552 : Extension dropped when using vars with image twig tag
