### PR TITLE
add JSqueeze support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The core provides the following filters in the `Assetic\Filter` namespace:
  * `JpegtranFilter`: optimize your JPEGs
  * `JSMinFilter`: minifies Javascript
  * `JSMinPlusFilter`: minifies Javascript
+ * `JSqueeze`: compresses Javascript
  * `LessFilter`: parses LESS into CSS (using less.js with node.js)
  * `LessphpFilter`: parses LESS into CSS (using lessphp)
  * `OptiPngFilter`: optimize your PNGs

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,16 @@
         "cssmin/cssmin": "*",
         "mrclay/minify": "*",
         "kamicane/packager": "*",
-        "joliclic/javascript-packer": "*"
+        "joliclic/javascript-packer": "*",
+        "patchwork/jsqueeze": "*"
     },
     "suggest": {
         "twig/twig": "Assetic provides the integration with the Twig templating engine",
         "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
         "leafo/scssphp": "Assetic provides the integration with the scssphp SCSS compiler",
         "ptachoire/cssembed": "Assetic provides the integration with phpcssembed to embed data uris",
-        "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin"
+        "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin",
+        "patchwork/jsqueeze": "Assetic provides the integration with the JSqueeze JavaScript compressor"
     },
     "autoload": {
         "psr-0": { "Assetic": "src/" },

--- a/src/Assetic/Filter/JSqueezeFilter.php
+++ b/src/Assetic/Filter/JSqueezeFilter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+
+/**
+ * JSqueeze filter.
+ *
+ * @link https://github.com/nicolas-grekas/JSqueeze
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class JSqueezeFilter implements FilterInterface
+{
+    private $singleLine = true;
+    private $keepImportantComments = true;
+    private $specialVarRx = \JSqueeze::SPECIAL_VAR_RX;
+
+    public function setSingleLine($bool)
+    {
+        $this->singleLine = (bool) $bool;
+    }
+
+    public function setSpecialVarRx($specialVarRx)
+    {
+        $this->specialVarRx = $specialVarRx;
+    }
+
+    public function keepImportantComments($bool)
+    {
+        $this->keepImportantComments = (bool) $bool;
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+        $parser = new \JSqueeze;
+        $asset->setContent($parser->squeeze(
+            $asset->getContent(),
+            $this->singleLine,
+            $this->keepImportantComments,
+            $this->specialVarRx
+        ));
+    }
+}

--- a/tests/Assetic/Test/Filter/JSqueezeFilterTest.php
+++ b/tests/Assetic/Test/Filter/JSqueezeFilterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Asset\FileAsset;
+use Assetic\Filter\JSqueezeFilter;
+
+/**
+ * @group integration
+ */
+class JSqueezeFilterTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('JSqueeze')) {
+            $this->markTestSkipped('JSqueeze is not installed.');
+        }
+    }
+
+    public function testRelativeSourceUrlImportImports()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/jsmin/js.js');
+        $asset->load();
+
+        $filter = new JSqueezeFilter();
+        $filter->filterDump($asset);
+
+        $this->assertEquals(";var a='abc',bbb='u';", $asset->getContent());
+    }
+}


### PR DESCRIPTION
Add support for JSqueeze, a JavaScript minifier that has a compressing ratio comparable to that of YUI Compressor and UglifyJs.

See https://github.com/nicolas-grekas/JSqueeze/
