### PR TITLE
Fix travis php 5.3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 before_script:
     # php deps
     - composer self-update
-    - composer install --dev
+    - phpversion=$(phpenv version); if [[ $phpversion =~ 5\.3\.* ]]; then composer install --dev --prefer-source; else composer install --dev; fi;
 
     # node deps
     - npm install uglify-js@1 && mkdir -p vendor/uglifyjs && mv node_modules vendor/uglifyjs


### PR DESCRIPTION
https://travis-ci.org/kriswallsmith/assetic/jobs/18190826

This was supposed to be fixed as noted here:
https://github.com/travis-ci/travis-ci/issues/1385

This is mostly a hack for php 5.3 travis builds to use `composer install
--dev --prefer-source` so that builds can be completed.

I tested the build off my fork as well: [![Build Status](https://travis-ci.org/Andrewpk/assetic.png?branch=master)](https://travis-ci.org/Andrewpk/assetic)
