### PR TITLE
updated JSqueezeFilter namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The core provides the following filters in the `Assetic\Filter` namespace:
  * `JpegtranFilter`: optimize your JPEGs
  * `JSMinFilter`: minifies Javascript
  * `JSMinPlusFilter`: minifies Javascript
- * `JSqueeze`: compresses Javascript
+ * `JSqueezeFilter`: compresses Javascript
  * `LessFilter`: parses LESS into CSS (using less.js with node.js)
  * `LessphpFilter`: parses LESS into CSS (using lessphp)
  * `OptiPngFilter`: optimize your PNGs


### PR DESCRIPTION
In the core provided filters namespace list changed:
JSqueeze to JSqueezeFilter
