### PR TITLE
issue with CssRewriteFilter

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -47,13 +47,13 @@ class CssRewriteFilter extends BaseCssFilter
             $host = '';
 
             // pop entries off the target until it fits in the source
-            if ('.' == dirname($sourcePath)) {
+            if ('.' == dirname($sourceBase)) {
                 $path = str_repeat('../', substr_count($targetPath, '/'));
             } elseif ('.' == $targetDir = dirname($targetPath)) {
-                $path = dirname($sourcePath).'/';
+                $path = dirname($sourceBase).'/';
             } else {
                 $path = '';
-                while (0 !== strpos($sourcePath, $targetDir)) {
+                while (0 !== strpos($sourceBase, $targetDir)) {
                     if (false !== $pos = strrpos($targetDir, '/')) {
                         $targetDir = substr($targetDir, 0, $pos);
                         $path .= '../';
@@ -63,7 +63,7 @@ class CssRewriteFilter extends BaseCssFilter
                         break;
                     }
                 }
-                $path .= ltrim(substr(dirname($sourcePath).'/', strlen($targetDir)), '/');
+                $path .= ltrim(substr(($sourceBase.'/'), strlen($targetDir)), '/');
             }
         }
 


### PR DESCRIPTION
i have situation where i have a php controller assigned to url http://my.domain.com/cms/assets/core_css.php which returns a a combined css file. When i wanted to rewrite CSS urls for one of the matching the new relative urls, it didn't seem to work.

My asset folder is in the root directory.

Controller:

```
public function action_core_css()
    {
// check for enviroment
        $this->debug = \Fuel::$env == \FUEL::PRODUCTION ? false : true;

        $this->frontendDepend = 'assets'.DS.'frontend-depend'.DS;
        $this->frontendApp = 'assets'.DS.'frontend-app'.DS;

        $this->adminDepend = 'assets'.DS.'admin-depend'.DS;
        $this->adminApp = 'assets'.DS.'admin-app'.DS;

        $ac = new AssetCollection(array(
            new FileAsset($this->adminDepend.'bootstrap'.DS.'css'.DS.'bootstrap.css'),
            new FileAsset($this->adminDepend.'jquery.fileupload'.DS.'css'.DS.'blueimp-gallery.min.css'),
            new FileAsset($this->adminDepend.'jquery.fileupload'.DS.'css'.DS.'jquery.fileupload-ui.css'),
            new FileAsset($this->adminApp.'css'.DS.'warp-uuberadmin-strap.css'),
            new FileAsset($this->adminApp.'css'.DS.'warp-uuberadmin-style.css'),
        ));
        foreach ($ac as $leaf) {
            $leaf->setTargetPath('ubercms/assets/core_css/');
        }
       // $ac->setTargetPath('ubercms/assets/core_css/');

        $am = new AssetManager();
        $am->set('ubercms_core_css', $ac);

        $fm = new FilterManager();
        $fm->set('css_min', new CssMinFilter());
        $fm->set('css_url', new CssRewriteFilter());


        $factory = new AssetFactory('assets');
        $factory->setAssetManager($am);
        $factory->setFilterManager($fm);
        $factory->setDebug($this->debug);
        $factory->addWorker(new CacheBustingWorker());

        // connect asset with filter
        $css = $factory->createAsset(array(
            '@ubercms_core_css',
        ), array(
            'css_url',
            '?css_min' // ignore if dev
        ));

        // save cache
        // assetic takes care of checking if asset is already there
        $content = new AssetCache(
          $css,
          new FilesystemCache('assets'.DS.'cache')
        );

        header('Content-Type: text/css');
        header('Last-Modified: '.gmdate('D, d M Y H:i:s', $content->getLastModified()).' GMT');

        echo $content->dump();
    }
```

created CSS urls where:

```
'../../fonts/glyphicons-halflings-regular.eot
```

instead of:

```
'../../assets/admin-depend/bootstrap/fonts/glyphicons-halflings-regular.eot
```

I looked at the cssRewriteFilter source code and found that i didn't have correct target paths. So i added this to the code:

```
 foreach ($ac as $leaf) {
      $leaf->setTargetPath('ubercms/assets/core_css/');
 }
```

Next i found, that my in the cssRewriteFilter change $sourcePath to $sourceBase in few places because i $sourceBase is the path to the file and the $sourcePath is name of the file plus the extension. I ended up creating a working code. As i only picked up assetic few days ago, i am not sure, if it's my lack of knowledge or is it a bug.
