### PR TITLE
Refactoring of twig token parser: extract method

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -16,11 +16,11 @@ use Assetic\Factory\AssetFactory;
 
 class AsseticTokenParser extends \Twig_TokenParser
 {
-    private $factory;
-    private $tag;
-    private $output;
-    private $single;
-    private $extensions;
+    protected $factory;
+    protected $tag;
+    protected $output;
+    protected $single;
+    protected $extensions;
 
     /**
      * Constructor.

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -45,6 +45,28 @@ class AsseticTokenParser extends \Twig_TokenParser
 
     public function parse(\Twig_Token $token)
     {
+        list($inputs, $filters, $name, $attributes) = $this->parseStartOfTag();
+        $stream = $this->parser->getStream();
+
+        $body = $this->parser->subparse(array($this, 'testEndTag'), true);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        if ($this->single && 1 < count($inputs)) {
+            $inputs = array_slice($inputs, -1);
+        }
+
+        if (!$name) {
+            $name = $this->factory->generateAssetName($inputs, $filters, $attributes);
+        }
+
+        $asset = $this->factory->createAsset($inputs, $filters, $attributes + array('name' => $name));
+
+        return $this->createNode($asset, $body, $inputs, $filters, $name, $attributes, $token->getLine(), $this->getTag());
+    }
+
+    protected function parseStartOfTag()
+    {
         $inputs = array();
         $filters = array();
         $name = null;
@@ -119,21 +141,7 @@ class AsseticTokenParser extends \Twig_TokenParser
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        $body = $this->parser->subparse(array($this, 'testEndTag'), true);
-
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
-
-        if ($this->single && 1 < count($inputs)) {
-            $inputs = array_slice($inputs, -1);
-        }
-
-        if (!$name) {
-            $name = $this->factory->generateAssetName($inputs, $filters, $attributes);
-        }
-
-        $asset = $this->factory->createAsset($inputs, $filters, $attributes + array('name' => $name));
-
-        return $this->createNode($asset, $body, $inputs, $filters, $name, $attributes, $token->getLine(), $this->getTag());
+        return array($inputs, $filters, $name, $attributes);
     }
 
     public function getTag()


### PR DESCRIPTION
Extracted method, parsing the head of twig tags. This change allows anyone write other token parsers (i.e., I want to implement tags `register_javascript` and `register_stylesheet`)
