### PR TITLE
Stop FilesystemCacheTest from failing if /tmp/foo exists

### DIFF
--- a/tests/Assetic/Test/Cache/FilesystemCacheTest.php
+++ b/tests/Assetic/Test/Cache/FilesystemCacheTest.php
@@ -15,9 +15,13 @@ use Assetic\Cache\FilesystemCache;
 
 class FilesystemCacheTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCache()
+    public function testWithExistingDir()
     {
-        $cache = new FilesystemCache(sys_get_temp_dir());
+        $dir = sys_get_temp_dir().'/assetic_filesystemcachetest_testcache';
+        $this->removeDir($dir);
+        mkdir($dir);
+
+        $cache = new FilesystemCache($dir);
 
         $this->assertFalse($cache->has('foo'));
 
@@ -33,19 +37,18 @@ class FilesystemCacheTest extends \PHPUnit_Framework_TestCase
     public function testSetCreatesDir()
     {
         $dir = sys_get_temp_dir().'/assetic/fscachetest';
-
-        $tearDown = function() use ($dir) {
-            array_map('unlink', glob($dir.'/*'));
-            @rmdir($dir);
-        };
-
-        $tearDown();
+        $this->removeDir($dir);
 
         $cache = new FilesystemCache($dir);
         $cache->set('foo', 'bar');
 
         $this->assertFileExists($dir.'/foo');
 
-        $tearDown();
+        $this->removeDir($dir);
+    }
+
+    private function removeDir($dir) {
+        array_map('unlink', glob($dir.'/*'));
+        @rmdir($dir);
     }
 }


### PR DESCRIPTION
- this seems like a fairly likely file to exist
- if the test gets aborted for some reason, the cleanup might not happen, and then the test will fail
- rename testCache() to be clearer

HHVMs test runs don't use a clean VM each time, so this is an intermittent failure.
