### PR TITLE
Update last-modified for AssetCache asset

### DIFF
--- a/src/Assetic/Asset/AssetCache.php
+++ b/src/Assetic/Asset/AssetCache.php
@@ -24,6 +24,7 @@ class AssetCache implements AssetInterface
 {
     private $asset;
     private $cache;
+    private $lastModified;
 
     public function __construct(AssetInterface $asset, CacheInterface $cache)
     {
@@ -48,7 +49,7 @@ class AssetCache implements AssetInterface
 
     public function load(FilterInterface $additionalFilter = null)
     {
-        $cacheKey = self::getCacheKey($this->asset, $additionalFilter, 'load');
+        $cacheKey = self::getCacheKey($this, $additionalFilter, 'load');
         if ($this->cache->has($cacheKey)) {
             $this->asset->setContent($this->cache->get($cacheKey));
 
@@ -61,7 +62,7 @@ class AssetCache implements AssetInterface
 
     public function dump(FilterInterface $additionalFilter = null)
     {
-        $cacheKey = self::getCacheKey($this->asset, $additionalFilter, 'dump');
+        $cacheKey = self::getCacheKey($this, $additionalFilter, 'dump');
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }
@@ -107,9 +108,14 @@ class AssetCache implements AssetInterface
         $this->asset->setTargetPath($targetPath);
     }
 
+    public function setLastModified($lastModified)
+    {
+        $this->lastModified = $lastModified;
+    }
+
     public function getLastModified()
     {
-        return $this->asset->getLastModified();
+        return max($this->asset->getLastModified(), $this->lastModified);
     }
 
     public function getVars()

--- a/tests/Assetic/Test/Asset/AssetCacheTest.php
+++ b/tests/Assetic/Test/Asset/AssetCacheTest.php
@@ -172,4 +172,15 @@ class AssetCacheTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(123, $this->asset->getLastModified(), '->getLastModified() returns the inner asset last modified');
     }
+
+    public function testSetLastModified()
+    {
+        $this->inner->expects($this->once())
+            ->method('getLastModified')
+            ->will($this->returnValue(123));
+
+        $this->asset->setLastModified(234);
+
+        $this->assertEquals(234, $this->asset->getLastModified(), '->getLastModified() returns the modified last modified');
+    }
 }


### PR DESCRIPTION
This feature will allow to fix LESS and SASS filters caching problems when using @import (see #127 and #169)

And after changes in AsseticController similar with https://github.com/covex-nn/AsseticBundle/commit/8cd3382c2356718d3febdb214be045c0510f041d there won't be any problems with caching @imports
