### PR TITLE
Add setFormatter option to Scssphpfilter

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -31,6 +31,8 @@ class ScssphpFilter implements DependencyExtractorInterface
 
     private $customFunctions = array(); 
 
+    private $formatter;
+
     public function enableCompass($enable = true)
     {
         $this->compass = (Boolean) $enable;
@@ -58,6 +60,10 @@ class ScssphpFilter implements DependencyExtractorInterface
             $sc->registerFunction($name,$callable);
         }
 
+        if ($this->formatter) {
+            $sc->setFormatter($this->formatter);
+        }
+
         $asset->setContent($sc->compile($asset->getContent()));
     }
 
@@ -78,6 +84,12 @@ class ScssphpFilter implements DependencyExtractorInterface
 
     public function filterDump(AssetInterface $asset)
     {
+
+    }
+
+    public function setFormatter($formatter)
+    {
+        $this->formatter = $formatter;
     }
 
     public function getChildren(AssetFactory $factory, $content, $loadPath = null)

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -104,16 +104,35 @@ EOF;
     {
         $asset = new StringAsset('.foo{ color: bar(); }');
         $asset->load();
-        
+
         $filter = $this->getFilter();
         $filter->registerFunction('bar',function(){ return 'red';});
         $filter->filterLoad($asset);
-        
+
         $expected = new StringAsset('.foo{ color: red;}');
         $expected->load();
         $filter->filterLoad($expected);
 
         $this->assertEquals($expected->getContent(), $asset->getContent(), 'custom function can be registered');
+    }
+
+    public function testSetFormatter()
+    {
+        $actual = new StringAsset(".foo {\n  color: #fff;\n}");
+        $actual->load();
+
+        $filter = $this->getFilter();
+        $filter->setFormatter("scss_formatter_compressed");
+        $filter->filterLoad($actual);
+
+        $expected = new StringAsset('.foo{color:#fff;}');
+        $expected->load();
+
+        $this->assertEquals(
+            $expected->getContent(),
+            $actual->getContent(),
+            'scss_formatter can be changed'
+        );
     }
 
     // private


### PR DESCRIPTION
This adds the ability to change the formatter used in the ScssphpFilter. The [docs](http://leafo.net/scssphp/docs/#output_formatting) have more info.
