### PR TITLE
fix BaseNodeFilter.php NODE_PATH for Windows

### DIFF
--- a/src/Assetic/Filter/BaseNodeFilter.php
+++ b/src/Assetic/Filter/BaseNodeFilter.php
@@ -35,7 +35,7 @@ abstract class BaseNodeFilter extends BaseProcessFilter
         $pb = parent::createProcessBuilder($arguments);
 
         if ($this->nodePaths) {
-            $pb->setEnv('NODE_PATH', implode(':', $this->nodePaths));
+            $pb->setEnv('NODE_PATH', implode(PATH_SEPARATOR, $this->nodePaths));
             $this->mergeEnv($pb);
         }
 


### PR DESCRIPTION
On Windows NODE_PATH use ';' instead of ':' for separating paths in the NODE_PATH
