### PR TITLE
Add option to apply a filter to an AssetCollection only after all inner assets are dumped

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -13,8 +13,10 @@ namespace Assetic\Asset;
 
 use Assetic\Asset\Iterator\AssetCollectionFilterIterator;
 use Assetic\Asset\Iterator\AssetCollectionIterator;
+use Assetic\Asset\StringAsset;
 use Assetic\Filter\FilterCollection;
 use Assetic\Filter\FilterInterface;
+use Assetic\Filter\GrouppedFilterInterface;
 
 /**
  * A collection of assets.
@@ -68,6 +70,19 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
     public function add(AssetInterface $asset)
     {
         $this->assets[] = $asset;
+    }
+
+    private function applyGrouppedFilters($parts){
+        $stringAsset = new StringAsset(implode("\n", $parts));
+        $stringAsset->load();
+
+        foreach($this->filters as $filter){
+            if($filter instanceOf GrouppedFilterInterface){
+                $filter->filterDump($stringAsset);
+            }
+        }
+
+        return $stringAsset->getContent();
     }
 
     public function removeLeaf(AssetInterface $needle, $graceful = false)
@@ -151,7 +166,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
             $parts[] = $asset->dump($additionalFilter);
         }
 
-        return implode("\n", $parts);
+        return $this->applyGrouppedFilters($parts);
     }
 
     public function getContent()

--- a/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
+++ b/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
@@ -12,6 +12,7 @@
 namespace Assetic\Asset\Iterator;
 
 use Assetic\Asset\AssetCollectionInterface;
+use Assetic\Filter\GrouppedFilterInterface;
 
 /**
  * Iterates over an asset collection.
@@ -74,7 +75,9 @@ class AssetCollectionIterator implements \RecursiveIterator
 
         // cascade filters
         foreach ($this->filters as $filter) {
-            $clone->ensureFilter($filter);
+            if(!($filter instanceOf GrouppedFilterInterface)){
+                $clone->ensureFilter($filter);
+            }
         }
 
         return $clone;

--- a/src/Assetic/Filter/FilterCollection.php
+++ b/src/Assetic/Filter/FilterCollection.php
@@ -66,7 +66,9 @@ class FilterCollection implements FilterInterface, \IteratorAggregate, \Countabl
     public function filterDump(AssetInterface $asset)
     {
         foreach ($this->filters as $filter) {
-            $filter->filterDump($asset);
+            if(!($filter instanceOf GrouppedFilterInterface)){
+                $filter->filterDump($asset);
+            }
         }
     }
 

--- a/src/Assetic/Filter/GrouppedFilterInterface.php
+++ b/src/Assetic/Filter/GrouppedFilterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+/**
+ * A filter manipulates assets at load and dump as a collection.
+ *
+ * @author José Ramón Fernandez Leis <jdeveloper.inxenio@gmail.com>
+ */
+interface GrouppedFilterInterface extends FilterInterface
+{
+
+}

--- a/tests/Assetic/Test/Asset/AssetCollectionTest.php
+++ b/tests/Assetic/Test/Asset/AssetCollectionTest.php
@@ -42,6 +42,18 @@ class AssetCollectionTest extends \PHPUnit_Framework_TestCase
         $coll->dump();
     }
 
+    public function testDumpGroupedFilter()
+    {
+        $filter = $this->getMock('Assetic\\Filter\\GrouppedFilterInterface');
+        $stringAsset = new StringAsset("1\n2");
+
+        $stringAsset->load();
+        $filter->expects($this->once())->method('filterDump')->with();
+
+        $coll = new AssetCollection(array(new StringAsset('1'), new StringAsset('2')), array($filter));
+        $coll->dump();
+    }
+
     public function testNestedCollectionLoad()
     {
         $content = 'foobar';


### PR DESCRIPTION
I was trying to make a gzip filter for js and css filies, using the system command gzip. All worked well dumping the assets when the assets arn't combined.

But if you try to combine several assets into a single file the problem arrives since all files are gzipped together and than joined togheter with \n. So the resulting file is not valid. It would be greet if a filter could be applied just the moment right before dumping it to disk, and I think it would not be just great for this usecase, but allso for minifying and such.
