### PR TITLE
Fix last modified time calculation of AssetReference (fixes #532, #537)

### DIFF
--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -31,6 +31,11 @@ class AssetReference implements AssetInterface
         $this->name = $name;
     }
 
+    public function getReferencedAsset()
+    {
+        return $this->am->get($this->name);
+    }
+
     public function ensureFilter(FilterInterface $filter)
     {
         $this->filters[] = $filter;

--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -251,6 +251,11 @@ class AssetFactory
     public function getLastModified(AssetInterface $asset)
     {
         $mtime = 0;
+
+        if ($asset instanceof AssetReference) {
+            $asset = $asset->getReferencedAsset();
+        }
+
         foreach ($asset instanceof AssetCollectionInterface ? $asset : array($asset) as $leaf) {
             $mtime = max($mtime, $leaf->getLastModified());
 


### PR DESCRIPTION
Fixes issues #532, #537. Properly calculates modified time of child assets.

More elegant solution than this #611 PR.
