### PR TITLE
NODE_PATH was overridden by $_SERVER value

### DIFF
--- a/src/Assetic/Filter/BaseNodeFilter.php
+++ b/src/Assetic/Filter/BaseNodeFilter.php
@@ -33,9 +33,9 @@ abstract class BaseNodeFilter extends BaseProcessFilter
     protected function createProcessBuilder(array $arguments = array())
     {
         $pb = parent::createProcessBuilder($arguments);
+        $this->mergeEnv($pb);
 
         if ($this->nodePaths) {
-            $this->mergeEnv($pb);
             $pb->setEnv('NODE_PATH', implode(':', $this->nodePaths));
         }
 


### PR DESCRIPTION
On BaseNodeFilter, NODE_PATH was overridden by $_SERVER value, even if it was set as an argument.

NODE_PATH can be set as the 2nd argument of a NodeFilter. The problem is that NODE_PATH is set, then $_SERVER environment is merged. If $_SERVER['NODE_PATH'] is set, it overrides previous value.

Also: $_SERVER was never merged with node environment unless NODE_PATH is set

I tried to make this change on 1.1.x branch, but I can't manage to make the test run. Travis build fail even on previous commit (before my change)