### PR TITLE
Added compress options for UglifyJS

### DIFF
--- a/src/Assetic/Filter/UglifyJs2Filter.php
+++ b/src/Assetic/Filter/UglifyJs2Filter.php
@@ -87,6 +87,10 @@ class UglifyJs2Filter extends BaseNodeFilter
 
         if ($this->compress) {
             $pb->add('--compress');
+
+            if (is_string($this->compress) && !empty($this->compress)) {
+                $pb->add(true === $this->compress ? '' : $this->compress);
+            }
         }
 
         if ($this->beautify) {

--- a/tests/Assetic/Test/Filter/UglifyJs2FilterTest.php
+++ b/tests/Assetic/Test/Filter/UglifyJs2FilterTest.php
@@ -20,7 +20,14 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class UglifyJs2FilterTest extends FilterTestCase
 {
+    /**
+     * @var FileAsset
+     */
     private $asset;
+
+    /**
+     * @var UglifyJs2Filter
+     */
     private $filter;
 
     protected function setUp()
@@ -88,6 +95,14 @@ class UglifyJs2FilterTest extends FilterTestCase
 
         $this->assertContains('var foo', $this->asset->getContent());
         $this->assertNotContains('var var1', $this->asset->getContent());
+    }
+
+    public function testCompressOptions()
+    {
+        $this->filter->setCompress('drop_console');
+        $this->filter->filterDump($this->asset);
+
+        $this->assertNotContains('console.log', $this->asset->getContent());
     }
 
     public function testMangle()


### PR DESCRIPTION
Refs #409

As per [the docs](https://github.com/mishoo/UglifyJS2#compressor-options), the `compress` option can contain a comma-separated list of values.
