### PR TITLE
Make the TypeScriptFilter use relative paths, rather than a temp file

### DIFF
--- a/src/Assetic/Filter/TypeScriptFilter.php
+++ b/src/Assetic/Filter/TypeScriptFilter.php
@@ -37,21 +37,13 @@ class TypeScriptFilter extends BaseNodeFilter
             ? array($this->nodeBin, $this->tscBin)
             : array($this->tscBin));
 
-        $templateName = basename($asset->getSourcePath());
-
-        $inputDirPath = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('input_dir');
-        $inputPath = $inputDirPath.DIRECTORY_SEPARATOR.$templateName.'.ts';
+        $inputPath = realpath($asset->getSourceRoot() . DIRECTORY_SEPARATOR . $asset->getSourcePath());
         $outputPath = tempnam(sys_get_temp_dir(), 'output');
-
-        mkdir($inputDirPath);
-        file_put_contents($inputPath, $asset->getContent());
 
         $pb->add($inputPath)->add('--out')->add($outputPath);
 
         $proc = $pb->getProcess();
         $code = $proc->run();
-        unlink($inputPath);
-        rmdir($inputDirPath);
 
         if (0 !== $code) {
             if (file_exists($outputPath)) {


### PR DESCRIPTION
The TypeScript definition import mechanism (which uses relative paths) does not work correctly when using the relative path to a given TypeScript library.

e.g. ///< reference path="../../typings/jquery.d.ts" / >

Due to the way that the TypeScriptFilter was copying the .ts file to a temp directory in order for the compiler to generate javascript, these relative filepaths were broken

In this pull request I have removed the temp file creation; loading the .ts file directly allows the definition files to be resolved correctly by the filesystem.
