### PR TITLE
Typescript translate relative paths to absolute paths

### DIFF
--- a/src/Assetic/Filter/BaseNodeFilter.php
+++ b/src/Assetic/Filter/BaseNodeFilter.php
@@ -35,6 +35,7 @@ abstract class BaseNodeFilter extends BaseProcessFilter
         $pb = parent::createProcessBuilder($arguments);
 
         if ($this->nodePaths) {
+            $pb->setEnv('NODE_PATH', implode(PATH_SEPARATOR, $this->nodePaths));
             $this->mergeEnv($pb);
             $pb->setEnv('NODE_PATH', implode(':', $this->nodePaths));
         }

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -36,7 +36,7 @@ class SassFilter extends BaseSassFilter
     private $debugInfo;
     private $lineNumbers;
     private $sourceMap;
-    private $loadPaths = array();
+    protected $loadPaths = array();
     private $cacheLocation;
     private $noCache;
     private $compass;

--- a/src/Assetic/Filter/TypeScriptFilter.php
+++ b/src/Assetic/Filter/TypeScriptFilter.php
@@ -25,10 +25,18 @@ class TypeScriptFilter extends BaseNodeFilter
     private $tscBin;
     private $nodeBin;
 
-    public function __construct($tscBin = '/usr/bin/tsc', $nodeBin = null)
+    /**
+     * @var bool
+     */
+    private $useRealPath = false;
+
+    public function __construct($tscBin = '/usr/bin/tsc', $nodeBin = null, $options = array())
     {
         $this->tscBin = $tscBin;
         $this->nodeBin = $nodeBin;
+        if (isset($options['use_real_path'])) {
+            $this->useRealPath = $options['use_real_path'] == true;
+        }
     }
 
     public function filterLoad(AssetInterface $asset)
@@ -44,7 +52,7 @@ class TypeScriptFilter extends BaseNodeFilter
         $outputPath = tempnam(sys_get_temp_dir(), 'output');
 
         mkdir($inputDirPath);
-        file_put_contents($inputPath, $asset->getContent());
+        file_put_contents($inputPath, $this->getAssetContent($asset));
 
         $pb->add($inputPath)->add('--out')->add($outputPath);
 
@@ -72,5 +80,26 @@ class TypeScriptFilter extends BaseNodeFilter
 
     public function filterDump(AssetInterface $asset)
     {
+    }
+
+    private function getAssetContent(AssetInterface $asset)
+    {
+        if ($this->useRealPath && $asset->getSourcePath() && $asset->getSourceRoot()) {
+            $pathInfo = pathinfo($asset->getSourcePath());
+            $dir = $asset->getSourceRoot() . DIRECTORY_SEPARATOR . $pathInfo['dirname'];
+
+            $func = function ($matches) use ($dir) {
+                $path = realpath($dir . DIRECTORY_SEPARATOR . $matches[2]);
+                if ($path === false) {
+                    $path = $matches[2];
+                }
+
+                return $matches[1] . $path;
+            };
+
+            return preg_replace_callback('|(\s*/{3}\s*<reference\s+path=")([^"]+)|', $func, $asset->getContent());
+        }
+
+        return $asset->getContent();
     }
 }

--- a/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
+++ b/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
@@ -86,9 +86,9 @@ TYPESCRIPT;
         $referenceCode = str_replace('%tmp_file%', $tmpFile, $referenceCode);
 
         // Load filter with use_real_path
-        $asset = new StringAsset($referenceCode, [], $tmpDir, 'test');
+        $asset = new StringAsset($referenceCode, array(), $tmpDir, 'test');
         $asset->load();
-        $filter = new TypeScriptFilter($this->tscBin, $this->nodeBin, ['use_real_path' => true]);
+        $filter = new TypeScriptFilter($this->tscBin, $this->nodeBin, array('use_real_path' => true));
         $filter->filterLoad($asset);
 
         unlink($tmpFile);

--- a/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
+++ b/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
@@ -98,13 +98,13 @@ TYPESCRIPT;
 
     public function relativeToAbsolutePathsDataProvider()
     {
-        return [
-            ['/// <reference path="%tmp_file%" />'],
-            ['/// <reference path="%tmp_file%"         />'],
-            ['///<reference path="%tmp_file%" />'],
-            ['///<reference path="%tmp_file%"/>'],
-            ['///<reference      path="%tmp_file%" />'],
-            ['    /// <reference path="%tmp_file%" />']
-        ];
+        return array(
+            array('/// <reference path="%tmp_file%" />'),
+            array('/// <reference path="%tmp_file%"         />'),
+            array('///<reference path="%tmp_file%" />'),
+            array('///<reference path="%tmp_file%"/>'),
+            array('///<reference      path="%tmp_file%" />'),
+            array('    /// <reference path="%tmp_file%" />')
+        );
     }
 }

--- a/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
+++ b/tests/Assetic/Test/Filter/TypeScriptFilterTest.php
@@ -11,6 +11,7 @@
 
 namespace Assetic\Test\Filter;
 
+use Assetic\Asset\FileAsset;
 use Assetic\Asset\StringAsset;
 use Assetic\Filter\TypeScriptFilter;
 
@@ -24,16 +25,20 @@ class TypeScriptFilterTest extends FilterTestCase
      */
     private $filter;
 
+    private $tscBin;
+
+    private $nodeBin;
+
     protected function setUp()
     {
-        $tscBin = $this->findExecutable('tsc', 'TSC_BIN');
-        $nodeBin = $this->findExecutable('node', 'NODE_BIN');
+        $this->tscBin = $this->findExecutable('tsc', 'TSC_BIN');
+        $this->nodeBin = $this->findExecutable('node', 'NODE_BIN');
 
-        if (!$tscBin) {
+        if (!$this->tscBin) {
             $this->markTestSkipped('Unable to find `tsc` executable.');
         }
 
-        $this->filter = new TypeScriptFilter($tscBin, $nodeBin);
+        $this->filter = new TypeScriptFilter($this->tscBin, $this->nodeBin);
     }
 
     protected function tearDown()
@@ -66,5 +71,42 @@ TYPESCRIPT;
 
         $this->assertContains('function greeter(person)', $asset->getContent());
         $this->assertNotContains('interface Person', $asset->getContent());
+    }
+
+    public function testRelativeToAbsolutepaths()
+    {
+        $tmpDir = sys_get_temp_dir();
+        $tmpName = uniqid('php_assetic_test') . '.ts';
+        $tmpFile = $tmpDir.DIRECTORY_SEPARATOR.$tmpName;
+        file_put_contents($tmpFile, '');
+
+        $typescript = <<<TYPESCRIPT
+/// <reference path="{$tmpName}" />
+/// <reference path="{$tmpName}"         />
+///<reference path="{$tmpName}" />
+///<reference path="{$tmpName}"/>
+///<reference      path="{$tmpName}" />
+     /// <reference path="{$tmpName}" />
+
+TYPESCRIPT;
+
+        $expectedOutput = <<<TYPESCRIPT
+/// <reference path="{$tmpFile}" />
+/// <reference path="{$tmpFile}"         />
+///<reference path="{$tmpFile}" />
+///<reference path="{$tmpFile}"/>
+///<reference      path="{$tmpFile}" />
+/// <reference path="{$tmpFile}" />
+
+TYPESCRIPT;
+
+        $asset = new StringAsset($typescript, [], $tmpDir, 'test');
+        $asset->load();
+        $filter = new TypeScriptFilter($this->tscBin, $this->nodeBin, ['use_real_path' => true]);
+        $filter->filterLoad($asset);
+
+        unlink($tmpFile);
+
+        $this->assertEquals($expectedOutput, $asset->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Typescript uses `<reference path="" />` to resolve dependencies on another files. This can cause problems with assetic, because assets are took out of their original place and they are put in tmp directory.

This pull request is similar to already opened PR for this https://github.com/kriswallsmith/assetic/pull/374 without any new activity for more than one year.

This change allows a new setting to use real path instead of relative one. When asset is loaded, it's checked for `<reference path="">` and all paths are replaced with real paths.

``` typescript
/// <reference path="absolute.ts" />
```

is translated to

``` typescript
/// <reference path="/project/absolute.ts" />
```