### PR TITLE
Fix Sass load path

### DIFF
--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -36,7 +36,6 @@ class SassFilter extends BaseSassFilter
     private $debugInfo;
     private $lineNumbers;
     private $sourceMap;
-    private $loadPaths = array();
     private $cacheLocation;
     private $noCache;
     private $compass;
@@ -81,16 +80,6 @@ class SassFilter extends BaseSassFilter
     public function setSourceMap($sourceMap)
     {
         $this->sourceMap = $sourceMap;
-    }
-
-    public function setLoadPaths(array $loadPaths)
-    {
-        $this->loadPaths = $loadPaths;
-    }
-
-    public function addLoadPath($loadPath)
-    {
-        $this->loadPaths[] = $loadPath;
     }
 
     public function setCacheLocation($cacheLocation)


### PR DESCRIPTION
Throws `Fatal error: Access level to Assetic\Filter\Sass\SassFilter::$loadPaths must be protected (as in class Assetic\Filter\Sass\BaseSassFilter) or weaker`

Since it’s already available thorugh `BaseSassFilter`, we don’t need it here.
