### PR TITLE
Fix for `PATH` separator in `BaseNodeFilter`

### DIFF
--- a/src/Assetic/Filter/BaseNodeFilter.php
+++ b/src/Assetic/Filter/BaseNodeFilter.php
@@ -36,7 +36,7 @@ abstract class BaseNodeFilter extends BaseProcessFilter
 
         if ($this->nodePaths) {
             $this->mergeEnv($pb);
-            $pb->setEnv('NODE_PATH', implode(':', $this->nodePaths));
+            $pb->setEnv('NODE_PATH', implode(PATH_SEPARATOR, $this->nodePaths));
         }
 
         return $pb;


### PR DESCRIPTION
Make it platform agnostic with `PATH_SEPARATOR`.
