### PR TITLE
fixed "Invalid argument supplied for foreach()" when called from a phar ...

### DIFF
--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -66,7 +66,9 @@ class HttpAsset extends BaseAsset
 
     public function getLastModified()
     {
-        if (false !== @file_get_contents($this->sourceUrl, false, stream_context_create(array('http' => array('method' => 'HEAD'))))) {
+        if (false !== @file_get_contents($this->sourceUrl, false, stream_context_create(array('http' => array('method' => 'HEAD'))))
+            && is_array($http_response_header)
+           ) {
             foreach ($http_response_header as $header) {
                 if (0 === stripos($header, 'Last-Modified: ')) {
                     list(, $mtime) = explode(':', $header, 2);


### PR DESCRIPTION
On a Symfony2 project packaged as phar I had "Invalid argument supplied for foreach()" for CSS files as well as for JS files. Works fine if the same project is not packaed as phar. This patch fixes it for me for both: Symfony2 project packaged as phar and non-phar.
