### PR TITLE
Prevent PHP warning when having an empty root

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -416,10 +416,7 @@ class AssetFactory
     private static function findRootDir($path, array $roots)
     {
         foreach ($roots as $root) {
-            if (empty($root)) {
-                continue;
-            }
-            if (0 === strpos($path, $root)) {
+            if (!empty($root) && 0 === strpos($path, $root)) {
                 return $root;
             }
         }

--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -416,6 +416,9 @@ class AssetFactory
     private static function findRootDir($path, array $roots)
     {
         foreach ($roots as $root) {
+            if (empty($root)) {
+                continue;
+            }
             if (0 === strpos($path, $root)) {
                 return $root;
             }


### PR DESCRIPTION
Hello!

strpos() generates a PHP warning when the needle ($root) is empty. Happened when using absolute paths to assets.

Hopes this helps.
Cheers
