### PR TITLE
Add filter to append separator to assets

### DIFF
--- a/src/Assetic/Filter/SeparatorFilter.php
+++ b/src/Assetic/Filter/SeparatorFilter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+
+/**
+ * Inserts a separator between assets to prevent merge failures
+ * e.g. missing semicolon at the end of a JS file
+ *
+ * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ */
+class SeparatorFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    private $separator;
+
+    /**
+     * Constructor.
+     *
+     * @param string $separator Separator to use between assets
+     */
+    public function __construct($separator = ';')
+    {
+        $this->separator = $separator;
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+        $asset->setContent($asset->getContent() . $this->separator);
+    }
+}

--- a/tests/Assetic/Test/Filter/SeparatorFilterTest.php
+++ b/tests/Assetic/Test/Filter/SeparatorFilterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Asset\StringAsset;
+use Assetic\Filter\SeparatorFilter;
+
+/**
+ * @group integration
+ */
+class SeparatorFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAppend()
+    {
+        $asset = new StringAsset('foobar');
+        $asset->load();
+
+        $filter = new SeparatorFilter('+');
+        $filter->filterDump($asset);
+
+        $this->assertEquals('foobar+', $asset->getContent());
+    }
+}


### PR DESCRIPTION
Appends a separator to assets before dumping to prevent merge failures, e.g. with a missing semicolon in a JS file. See owncloud/core#10327 for a real-world use case of this.