### PR TITLE
Fix relative url rewrite with same parent directory.

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -80,7 +80,7 @@ class CssRewriteFilter extends BaseCssFilter
 
             // document relative
             $url = $matches['url'];
-            while (0 === strpos($url, '../') && 2 <= substr_count($path, '/')) {
+            while (0 === strpos($url, '../') && '/../' !== substr($path, -4) && 2 <= substr_count($path, '/')) {
                 $path = substr($path, 0, strrpos(rtrim($path, '/'), '/') + 1);
                 $url = substr($url, 3);
             }

--- a/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
+++ b/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
@@ -56,6 +56,7 @@ class CssRewriteFilterTest extends \PHPUnit_Framework_TestCase
             array('body { background: url(%s); }', 'body.css', 'css/main.css', 'images/bg.gif', '../images/bg.gif'),
             array('body { background: url(%s); }', 'source/css/body.css', 'output/build/main.css', '../images/bg.gif', '../../source/images/bg.gif'),
             array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', '//example.com/images/bg.gif', '//example.com/images/bg.gif'),
+            array('body { background: url(%s); }', 'css/body.css', 'css/build/layout/main.css', '../images/foo.gif', '../../../images/foo.gif'),
 
             // url diffs
             array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', 'http://foo.com/bar.gif', 'http://foo.com/bar.gif'),


### PR DESCRIPTION
Source path: `assets/css/prx_media_48.css`

``` css
body {
    background-image:url("../../../files/xyz/startseite/bg/BG_Start-Koblenz.jpg");
}
```

Target path: `assets/theme-plus/proxy.php/css/d6cc649c/prx_media_48.css`

File location: `files/xyz/startseite/bg/BG_Start-Koblenz.jpg`

Expected result: `../../../../../files/xyz/startseite/bg/BG_Start-Koblenz.jpg`
Current result: : `../../../files/xyz/startseite/bg/BG_Start-Koblenz.jpg`

The problem is, that both have the same parent directory.
The while loop remove the deepest directory from the path, if the source url start with `../`, but this will also remove leading `../` from the path, but `../` parts must be stacked!
