### PR TITLE
[WIP] SourceMap dumping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.1",
         "symfony/process": "~2.1",
-        "koala-framework/sourcemaps": "~0.1@dev"
+        "koala-framework/sourcemaps": "dev-inline as 0.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4",

--- a/src/Assetic/Asset/AssetInterface.php
+++ b/src/Assetic/Asset/AssetInterface.php
@@ -64,16 +64,12 @@ interface AssetInterface
      */
     public function dump(FilterInterface $additionalFilter = null);
 
-    public function dumpSourceMap(FilterInterface $additionalFilter = null);
-
     /**
      * Returns the loaded content of the current asset.
      *
      * @return string The content
      */
     public function getContent();
-
-    public function getContentSourceMap();
 
     /**
      * Sets the content of the current asset.

--- a/src/Assetic/Asset/BaseAsset.php
+++ b/src/Assetic/Asset/BaseAsset.php
@@ -94,7 +94,6 @@ abstract class BaseAsset implements AssetInterface
 
         $filter->filterLoad($asset);
         $this->content = $asset->getContent();
-        $this->contentSourceMap = $asset->getContentSourceMap();
 
         $this->loaded = true;
     }
@@ -116,41 +115,14 @@ abstract class BaseAsset implements AssetInterface
         return $asset->getContent();
     }
 
-    public function dumpSourceMap(FilterInterface $additionalFilter = null)
-    {
-        if (!$this->loaded) {
-            $this->load();
-        }
-
-        $filter = clone $this->filters;
-        if ($additionalFilter) {
-            $filter->ensure($additionalFilter);
-        }
-
-        $asset = clone $this;
-        $filter->filterDump($asset);
-
-        return $asset->getContentSourceMap();
-    }
-
     public function getContent()
     {
         return $this->content;
     }
 
-    public function getContentSourceMap()
-    {
-        return $this->contentSourceMap;
-    }
-
     public function setContent($content)
     {
         $this->content = $content;
-    }
-
-    public function setContentSourceMap(\Kwf_SourceMaps_SourceMap $sourceMap)
-    {
-        $this->contentSourceMap = $sourceMap;
     }
 
     public function getSourceRoot()

--- a/src/Assetic/Filter/CoffeeScriptFilter.php
+++ b/src/Assetic/Filter/CoffeeScriptFilter.php
@@ -81,13 +81,16 @@ class CoffeeScriptFilter extends BaseNodeFilter
         unlink($input.'.js.map');
 
         $content = str_replace("\n".'//# sourceMappingURL='.basename($input).'.js.map'."\n", '', $content);
+
+
         $asset->setContent($content);
 
         $contentMap = json_decode($contentMap);
         unset($contentMap->file);
         unset($contentMap->sourceRoot);
         $contentMap->sources[0] = $asset->getSourceRoot().'/'.$asset->getSourcePath();
-        $asset->setContentSourceMap(new \Kwf_SourceMaps_SourceMap($contentMap, $content));
+        $map = new \Kwf_SourceMaps_SourceMap($contentMap, $content);
+        $asset->setContent($map->getFileContentsInlineMap());
     }
 
     public function filterDump(AssetInterface $asset)


### PR DESCRIPTION
(This is WIP, I want to get early feedback for)

Implement SourceMap dumping (see http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/, #208, #558)
- filters generate/modify sourcemaps
- AssetCollection concats sourcemaps
- handle files without sourcemap in AssetCollection

This is implemented using an external library https://github.com/koala-framework/sourcemaps

Currently only implemented for:
- CoffeeScriptFilter
- UglifyJs2Filter

TODO:
- [ ] Review API
- [ ] Implement other Filters
- [ ] Write Unit Tests
- Performance
  - [ ] don't generate any source map data at all if they are not used
  - [ ] Caching (with fast concat of sourcemaps)
- [ ] implement in AssetsWriter
- [ ] Optional output, disabled by default

Tested with:

```
$js = new FileAsset('js/foo.coffee', array(new CoffeeScriptFilter()));
$js = new FileAsset('js/xx.js', array(new UglifyJs2Filter()));
$js = new FileAsset('js/foo.coffee', array(new CoffeeScriptFilter(), new UglifyJs2Filter()));
$js = new AssetCollection(array(
    new FileAsset('js/xx.js', array(new UglifyJs2Filter()))
));
$js = new AssetCollection(array(
    new GlobAsset('js/*.coffee', array(new CoffeeScriptFilter())),
    new GlobAsset('js/*.js', array()),
), array(
    new UglifyJs2Filter()
));
echo $js->dump();
```

outputs:

```
console.log("xx");
//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImpzXC94eC5qcyJdLCJuYW1lcyI6WyJjb25zb2xlIiwibG9nIl0sIm1hcHBpbmdzIjoiQUFBQUEsUUFBUUMsSUFBSSIsIl94X29yZ19rb2FsYS1mcmFtZXdvcmtfbGFzdCI6eyJzb3VyY2UiOjAsIm9yaWdpbmFsTGluZSI6MCwib3JpZ2luYWxDb2x1bW4iOjEyLCJuYW1lIjoxfX0=
```
