### PR TITLE
optimize asset reference filenames

### DIFF
--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -129,6 +129,16 @@ class AssetReference implements AssetInterface
         $this->callAsset(__FUNCTION__, array($values));
     }
 
+    /**
+     * Returns the name of this asset reference.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
     // private
 
     private function callAsset($method, $arguments = array())

--- a/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
+++ b/src/Assetic/Asset/Iterator/AssetCollectionIterator.php
@@ -12,6 +12,7 @@
 namespace Assetic\Asset\Iterator;
 
 use Assetic\Asset\AssetCollectionInterface;
+use Assetic\Asset\AssetReference;
 
 /**
  * Iterates over an asset collection.
@@ -64,7 +65,10 @@ class AssetCollectionIterator implements \RecursiveIterator
             $clone = $this->clones[$asset] = clone $asset;
 
             // generate a target path based on asset name
-            $name = sprintf('%s_%d', pathinfo($asset->getSourcePath(), PATHINFO_FILENAME) ?: 'part', $this->key() + 1);
+            $partName = $asset instanceof AssetReference
+                ? $asset->getName()
+                : pathinfo($asset->getSourcePath(), PATHINFO_FILENAME);
+            $name = sprintf('%s_%d', $partName ?: 'part', $this->key() + 1);
 
             $name = $this->removeDuplicateVar($name);
 

--- a/tests/Assetic/Test/Asset/AssetReferenceTest.php
+++ b/tests/Assetic/Test/Asset/AssetReferenceTest.php
@@ -60,6 +60,11 @@ class AssetReferenceTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testReturnsName()
+    {
+        $this->assertSame('foo', $this->ref->getName());
+    }
+
     public function testLazyFilters()
     {
         $this->am->expects($this->never())->method('get');

--- a/tests/Assetic/Test/Asset/Iterator/AssetCollectionIteratorTest.php
+++ b/tests/Assetic/Test/Asset/Iterator/AssetCollectionIteratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Asset\Iterator;
+
+use Assetic\Asset\AssetReference;
+use Assetic\Asset\FileAsset;
+use Assetic\Asset\Iterator\AssetCollectionIterator;
+
+class AssetCollectionIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAppliesAssetReferenceNameToTargetPath()
+    {
+        $asset = new FileAsset('/path/to/asset');
+
+        $am = $this->getMock('Assetic\AssetManager');
+        $am->expects($this->any())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($asset));
+
+        $reference = new AssetReference($am, 'foo');
+
+        $collection = $this->getMock('Assetic\Asset\AssetCollectionInterface');
+        $collection->expects($this->once())
+            ->method('all')
+            ->will($this->returnValue(array($reference)));
+        $collection->expects($this->once())
+            ->method('getFilters')
+            ->will($this->returnValue(array()));
+        $collection->expects($this->once())
+            ->method('getVars')
+            ->will($this->returnValue(array()));
+
+        $iterator = new AssetCollectionIterator($collection, new \SplObjectStorage());
+        $asset = $iterator->current();
+
+        $this->assertSame('_foo_1', $asset->getTargetPath());
+    }
+}


### PR DESCRIPTION
Currently asset references get dumped with generic filenames like `fb32317_part_1.js`, `fb32317_part_2.js` etc.
Unfortunately these filenames don't tell you which asset reference they represent which would be very useful for debugging purposes IMO (especially when you have lots of assets).
So instead the asset reference name should be used instead of `part`: `fb32317_jquery_1.js`, `fb32317_bootstrap_2.js`.

What do you think?
