### PR TITLE
Removed asset load() from ScssphpFilter::getChildren

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -121,7 +121,7 @@ class ScssphpFilter implements DependencyExtractorInterface
             $file = $sc->findImport($match);
             if ($file) {
                 $children[] = $child = $factory->createAsset($file, array(), array('root' => $loadPath));
-                $child->load();
+                $child->ensureFilter($this);
                 $children = array_merge($children, $this->getChildren($factory, $child->getContent(), $loadPath));
             }
         }


### PR DESCRIPTION
The ScssphpFilter currently does $child->load(), in getChildren(), which is causing a severe slow-down in our set-up (AsseticBu=ndle/Symfony), because it causes the whole Foundation library (which is included via an CSS import statement) to recompile on each page load, even if the base asset is being loaded from the cache.

I have replaced $asset->load() with $asset->ensureFilter($this). I have not studied how Assetic works in depth, but this seems to be more similar to how the Less and Lessphp getChildren() methods work so I wondered whether this would be more appropriate.
