### PR TITLE
Make JSqueeze filter work with 1.x and 2.x (namespaced)

### DIFF
--- a/src/Assetic/Filter/JSqueezeFilter.php
+++ b/src/Assetic/Filter/JSqueezeFilter.php
@@ -23,16 +23,35 @@ class JSqueezeFilter implements FilterInterface
 {
     private $singleLine = true;
     private $keepImportantComments = true;
-    private $specialVarRx = \JSqueeze::SPECIAL_VAR_RX;
+    private $className;
+    private $specialVarRx = false;
+    private $defaultRx;
+
+    function __construct() {
+        // JSqueeze is namespaced since 2.x, this works with both 1.x and 2.x
+        if (class_exists('\\Patchwork\\JSqueeze')) {
+            $this->className = '\\Patchwork\\JSqueeze';
+            $this->defaultRx = \Patchwork\JSqueeze::SPECIAL_VAR_PACKER;
+        } else {
+            $this->className = '\\JSqueeze';
+            $this->defaultRx = \JSqueeze::SPECIAL_VAR_RX;
+        }
+    }
 
     public function setSingleLine($bool)
     {
         $this->singleLine = (bool) $bool;
     }
 
+    // call setSpecialVarRx(true) to enable global var/method/property
+    // renaming with the default regex (for 1.x or 2.x)
     public function setSpecialVarRx($specialVarRx)
     {
-        $this->specialVarRx = $specialVarRx;
+        if (true === $specialVarRx) {
+            $this->specialVarRx = $this->defaultRx;
+        } else {
+            $this->specialVarRx = $specialVarRx;
+        }
     }
 
     public function keepImportantComments($bool)
@@ -46,7 +65,7 @@ class JSqueezeFilter implements FilterInterface
 
     public function filterDump(AssetInterface $asset)
     {
-        $parser = new \JSqueeze();
+        $parser = new $this->className();
         $asset->setContent($parser->squeeze(
             $asset->getContent(),
             $this->singleLine,


### PR DESCRIPTION
JSqueeze 2.x just came out, and it's now namespaced. This should let the filter work with both 1.x and 2.x. Obviously it'd also be simple to just make it work with 2.x only if you wanted to go that way.

I thought about adding some helper bits to make it easier to use upstream's default special var regex on 2.x, but thought I'd just keep it simple for now. We could do something like have `setSpecialVarRx` accept 'true', and have that set the value to `JSqueeze::SPECIAL_VAR_PACKER` on 2.x.

@nicolas-grekas wdyt?

It'd be good to have this on the stable branches too.