### PR TITLE
Don't limit CssImportFilter to CSS

### DIFF
--- a/src/Assetic/Filter/ImportFilter.php
+++ b/src/Assetic/Filter/ImportFilter.php
@@ -17,11 +17,11 @@ use Assetic\Asset\HttpAsset;
 use Assetic\Factory\AssetFactory;
 
 /**
- * Inlines imported stylesheets.
+ * Inlines imported resources.
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
-class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterface
+class ImportFilter extends BaseCssFilter implements DependencyExtractorInterface
 {
     private $importFilter;
 
@@ -73,8 +73,8 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
             $importSource = $importRoot.'/'.$importPath;
             if (false !== strpos($importSource, '://') || 0 === strpos($importSource, '//')) {
                 $import = new HttpAsset($importSource, array($importFilter), true);
-            } elseif ('css' != pathinfo($importPath, PATHINFO_EXTENSION) || !file_exists($importSource)) {
-                // ignore non-css and non-existant imports
+            } elseif (!file_exists($importSource)) {
+                // ignore non-existant imports
                 return $matches[0];
             } else {
                 $import = new FileAsset($importSource, array($importFilter), $importRoot, $importPath);


### PR DESCRIPTION
When a file is imported using less (I guess the problem is the same with Sass), we have to know its parent location in order to have correct relative paths. Moreover if this file is imported by two files in different locations it becomes impossible to use relative paths.

This issue could be solved by inlining the imports. Currently there is a `CssImportFilter` but as its name implies it deals with CSS only. As with Less we can import file with css, less or no extension, my idea is to make this filter more generic by inlining **any** import.

I haven't updated tests, waiting for approval.
