### PR TITLE
don't delete $input if error is thrown.

### DIFF
--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -146,12 +146,12 @@ EOF;
 
         $proc = $pb->getProcess();
         $code = $proc->run();
-        unlink($input);
 
         if (0 !== $code) {
             throw FilterException::fromProcess($proc)->setInput($asset->getContent());
         }
 
+        unlink($input);
         $asset->setContent($proc->getOutput());
     }
 


### PR DESCRIPTION
make less easier to debug by not cleaning up the $input when erroring.
