### PR TITLE
Allow Coffeescript and Less filters to interface directly with binaries

### DIFF
--- a/tests/Assetic/Test/Filter/CoffeeScriptFilterTest.php
+++ b/tests/Assetic/Test/Filter/CoffeeScriptFilterTest.php
@@ -27,13 +27,12 @@ class CoffeeScriptFilterTest extends FilterTestCase
     protected function setUp()
     {
         $coffeeBin = $this->findExecutable('coffee', 'COFFEE_BIN');
-        $nodeBin = $this->findExecutable('node', 'NODE_BIN');
 
         if (!$coffeeBin) {
             $this->markTestSkipped('Unable to find `coffee` executable.');
         }
 
-        $this->filter = new CoffeeScriptFilter($coffeeBin, $nodeBin);
+        $this->filter = new CoffeeScriptFilter($coffeeBin);
     }
 
     protected function tearDown()

--- a/tests/Assetic/Test/Filter/LessFilterTest.php
+++ b/tests/Assetic/Test/Filter/LessFilterTest.php
@@ -27,15 +27,7 @@ class LessFilterTest extends FilterTestCase
 
     protected function setUp()
     {
-        if (!$nodeBin = $this->findExecutable('node', 'NODE_BIN')) {
-            $this->markTestSkipped('Unable to find `node` executable.');
-        }
-
-        if (!$this->checkNodeModule('less', $nodeBin)) {
-            $this->markTestSkipped('The "less" module is not installed.');
-        }
-
-        $this->filter = new LessFilter($nodeBin, isset($_SERVER['NODE_PATH']) ? array($_SERVER['NODE_PATH']) : array());
+        $this->filter = new LessFilter();
     }
 
     protected function tearDown()


### PR DESCRIPTION
This pull request aims to effect the following:

- Remove the need to specify the path to the node binary
- Remove the need to create, write to, and delete a temporary file.

It should be simply enough to interface with the binary directly, as both `lessc` and `coffee` have options to specify that input is expected from stdin. It's therefore not necessary to create a temporary file as we can write content directly in the process. 

This also makes it a lot easier to manage binary paths across environments, as all that is required is for the binary paths to be in the PATH. 

I may be unaware of a specific case for passing through the node binary, or for creating a temporary file when the filter loads an asset. If this is the case please mention it so I can be aware of this in the future.

All the tests seem to pass.