### PR TITLE
Workers weren't applied to asset leaves when LazyAssetManager was used (LessFilter not applied)

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -383,7 +383,7 @@ class AssetFactory
             foreach ($this->workers as $worker) {
                 $retval = $worker->process($leaf, $this);
 
-                if ($retval instanceof AssetInterface && $leaf !== $retval) {
+                if ($retval instanceof AssetInterface) {
                     $asset->replaceLeaf($leaf, $retval);
                 }
             }

--- a/src/Assetic/Factory/Worker/EnsureFilterWorker.php
+++ b/src/Assetic/Factory/Worker/EnsureFilterWorker.php
@@ -56,6 +56,7 @@ class EnsureFilterWorker implements WorkerInterface
             (self::CHECK_TARGET === (self::CHECK_TARGET & $this->flags) && preg_match($this->pattern, $asset->getTargetPath()))
         ) {
             $asset->ensureFilter($this->filter);
+            return $asset;
         }
     }
 }

--- a/tests/Assetic/Test/Factory/AssetFactoryTest.php
+++ b/tests/Assetic/Test/Factory/AssetFactoryTest.php
@@ -290,11 +290,11 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyWorkers()
     {
-        $assetLeaf = $this->getMock('Assetic\Asset\AssetInterface');
-        $worker = $this->getMockBuilder('Assetic\Factory\Worker\EnsureFilterWorker')
+        $assetLeaf = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $worker = $this->getMockBuilder('Assetic\\Factory\\Worker\\EnsureFilterWorker')
             ->disableOriginalConstructor()
             ->getMock();
-        $assetCollection = $this->getMockBuilder('Assetic\Asset\AssetCollection')
+        $assetCollection = $this->getMockBuilder('Assetic\\Asset\\AssetCollection')
             ->setConstructorArgs(array(
                 array($assetLeaf)
             ))
@@ -314,7 +314,7 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
         $assetCollection->expects($this->once())
             ->method('replaceLeaf')
-            ->with($this->isInstanceOf('Assetic\Asset\AssetInterface'), $this->isInstanceOf('Assetic\Asset\AssetInterface'));
+            ->with($this->isInstanceOf('Assetic\\Asset\\AssetInterface'), $this->isInstanceOf('Assetic\\Asset\\AssetInterface'));
 
         // reflection
         $factoryReflection = new \ReflectionClass(get_class($this->factory));
@@ -325,6 +325,6 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
         $applyWorkers = $factoryReflection->getMethod('applyWorkers');
         $applyWorkers->setAccessible(true);
-        $this->assertInstanceOf('Assetic\Asset\AssetCollection', $applyWorkers->invoke($this->factory, $assetCollection));
+        $this->assertInstanceOf('Assetic\\Asset\\AssetCollection', $applyWorkers->invoke($this->factory, $assetCollection));
     }
 }

--- a/tests/Assetic/Test/Factory/Worker/EnsureFilterWorkerTest.php
+++ b/tests/Assetic/Test/Factory/Worker/EnsureFilterWorkerTest.php
@@ -31,7 +31,7 @@ class EnsureFilterWorkerTest extends \PHPUnit_Framework_TestCase
             ->with($filter);
 
         $worker = new EnsureFilterWorker('/\.css$/', $filter);
-        $worker->process($asset, $factory);
+        $this->assertInstanceOf('Assetic\\Asset\\AssetInterface', $worker->process($asset, $factory));
     }
 
     public function testNonMatch()
@@ -48,6 +48,6 @@ class EnsureFilterWorkerTest extends \PHPUnit_Framework_TestCase
         $asset->expects($this->never())->method('ensureFilter');
 
         $worker = new EnsureFilterWorker('/\.css$/', $filter);
-        $worker->process($asset, $factory);
+        $this->assertNull($worker->process($asset, $factory));
     }
 }


### PR DESCRIPTION
Everything is in the title !

I don't know how to write the tests. I discovered the bug using symfony/assetic-bundle and I don't know how to trigger the bug outside of the bundle. I wrote this kind of config : 

``` yaml
assetic:
    assets:
        app_main_css:
            inputs:
                - %kernel.root_dir%/../web/bundles/appcore/css/main.less
                - %kernel.root_dir%/../web/bundles/appcore/css/popup.less
            output: css/app-main.css
```

When I use use_controller option, assetic generates an asset url like this : `/app_dev.php/css/4a8dd08_part_1.css`

LessFilter should be applied to .less files as I have set the option. app-main.css is not concerned, but its leaves should be. It is the purpose of applyWorker method to apply worker recursively, but this method is broken because retval is not returned by the EnsureFilterWorker, and the test in applyWorker is too strict.

I fixed these problems and it's working fine.
