### PR TITLE
ScssphpFilter - do not add empty load path as import path

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -111,7 +111,10 @@ class ScssphpFilter implements DependencyExtractorInterface
     public function getChildren(AssetFactory $factory, $content, $loadPath = null)
     {
         $sc = new Compiler();
-        $sc->addImportPath($loadPath);
+        if ($loadPath !== null) {
+            $sc->addImportPath($loadPath);
+        }
+
         foreach ($this->importPaths as $path) {
             $sc->addImportPath($path);
         }

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -155,6 +155,18 @@ EOF;
         $this->assertCount(2, $children);
     }
 
+    public function testGetChildrenEmptyPath()
+    {
+        $factory = new AssetFactory(__DIR__.'/fixtures/sass');
+
+        $filter = $this->getFilter();
+        $filter->addImportPath(__DIR__.'/fixtures/sass');
+
+        $children = $filter->getChildren($factory, '@import "main";');
+
+        $this->assertCount(2, $children);
+    }
+
     public function testSetVariables()
     {
         $filter = $this->getFilter();


### PR DESCRIPTION
This has in part to do with #164 and in part with leafo/scssphp#237.

When you iterate in https://github.com/kriswallsmith/assetic/blob/master/src/Assetic/Factory/AssetFactory.php#L254 over a AssetReference that references a AssetCollection the call to getSourceDirectory() in https://github.com/kriswallsmith/assetic/blob/master/src/Assetic/Factory/AssetFactory.php#L277 would return nothing (null).

The ScssphpFilter would then call addImportPath() on the scss compiler with null which results in an exception "call_user_func() expects parameter 1 to be a valid callback, no array or string given", which would in turn keep imports from being parsed and replaced properly