### PR TITLE
Added the possibility to set/add option to the process builder of ReactJsxFilter

### DIFF
--- a/src/Assetic/Filter/ReactJsxFilter.php
+++ b/src/Assetic/Filter/ReactJsxFilter.php
@@ -16,6 +16,7 @@ class ReactJsxFilter extends BaseNodeFilter
 {
     private $jsxBin;
     private $nodeBin;
+    private $options = [];
 
     public function __construct($jsxBin = '/usr/bin/jsx', $nodeBin = null)
     {
@@ -42,6 +43,10 @@ class ReactJsxFilter extends BaseNodeFilter
             ->add($outputDir)
             ->add('--no-cache-dir')
         ;
+
+        foreach ($this->options as $option) {
+            $builder->add($option);
+        }
 
         $proc = $builder->getProcess();
         $code = $proc->run();
@@ -71,5 +76,25 @@ class ReactJsxFilter extends BaseNodeFilter
 
     public function filterDump(AssetInterface $asset)
     {
+    }
+
+    /**
+     * Set options used by the process builder
+     *
+     * @param array $options
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Add option used by the process builder
+     *
+     * @param string $option
+     */
+    public function addOption($option)
+    {
+        $this->options[] = $option;
     }
 }


### PR DESCRIPTION
Very useful in case we want to use `jsx` with some custom options, like `--harmony`, mandatory if we want to use the [ES6 classes with React 0.13](https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#plain-javascript-classes).

```
$filter = new \Assetic\Filter\ReactJsxFilter();
$filter->addOption('--harmony');
```

or

```
$filter = new \Assetic\Filter\ReactJsxFilter();
$filter->setOptions(['--harmony']);
```
