### PR TITLE
Apparently you can't rely on glob() to return files in a predictable order

### DIFF
--- a/src/Assetic/Asset/GlobAsset.php
+++ b/src/Assetic/Asset/GlobAsset.php
@@ -100,6 +100,7 @@ class GlobAsset extends AssetCollection
             $glob = VarUtils::resolve($glob, $this->getVars(), $this->getValues());
 
             if (false !== $paths = glob($glob)) {
+                sort($paths);
                 foreach ($paths as $path) {
                     if (is_file($path)) {
                         $asset = new FileAsset($path, array(), $this->getSourceRoot(), null, $this->getVars());


### PR DESCRIPTION
Assets like `Resources/public/scripts/*/*/*.js` scan with different sorting from cli and web on the same server

`console assetic:dump` return 
```
Resources/public/scripts/components/generic/obb-tabdrop.js
Resources/public/scripts/components/generic/obb-tab.js
```
but from web 
```
Resources/public/scripts/components/generic/obb-tab.js
Resources/public/scripts/components/generic/obb-tabdrop.js
```


Info
```
eugene@e63a1c8df7ab:/opt/app/obb$ php -v
PHP 5.5.9-1ubuntu4.9 (cli) (built: Apr 17 2015 11:44:57) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
eugene@e63a1c8df7ab:/opt/app/obb$ ldd --version
ldd (Ubuntu EGLIBC 2.19-0ubuntu6.5) 2.19
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```