### PR TITLE
Filter (React JSX): Search local node_modules directory.

### DIFF
--- a/src/Assetic/Filter/ReactJsxFilter.php
+++ b/src/Assetic/Filter/ReactJsxFilter.php
@@ -17,8 +17,22 @@ class ReactJsxFilter extends BaseNodeFilter
     private $jsxBin;
     private $nodeBin;
 
-    public function __construct($jsxBin = '/usr/bin/jsx', $nodeBin = null)
+    public function __construct($jsxBin = '/usr/bin/jsx', $nodeBin = null, array $nodePaths = array())
     {
+        $this->setNodePaths($nodePaths);
+
+        if (!file_exists($jsxBin)) {
+            $localBins = array('/.bin/jsx', '/react-tools/bin/jsx');
+            foreach ($this->getNodePaths() as $nodePath) {
+                foreach ($localBins as $localBin) {
+                    if (file_exists($localJsxBin = $nodePath . $localBin)) {
+                        $jsxBin = $localJsxBin;
+                        break 2;
+                    }
+                }
+            }
+        }
+
         $this->jsxBin = $jsxBin;
         $this->nodeBin = $nodeBin;
     }

--- a/tests/Assetic/Test/Filter/ReactJsxFilterTest.php
+++ b/tests/Assetic/Test/Filter/ReactJsxFilterTest.php
@@ -8,31 +8,51 @@ use Assetic\Filter\ReactJsxFilter;
 class ReactJsxFilterTest extends FilterTestCase
 {
     /**
-     * @var ReactJsxFilter
+     * @var string
      */
-    private $filter;
+    private $jsxBin;
+
+    /**
+     * @var string
+     */
+    private $nodeBin;
 
     protected function setUp()
     {
-        $jsxBin = $this->findExecutable('jsx', 'JSX_BIN');
-        $nodeBin = $this->findExecutable('node', 'NODE_BIN');
+        $this->jsxBin = $this->findExecutable('jsx', 'JSX_BIN');
+        $this->nodeBin = $this->findExecutable('node', 'NODE_BIN');
 
-        if (!$jsxBin) {
+        if (!$this->jsxBin) {
             $this->markTestSkipped("Unable to find `jsx` executable.");
         }
-
-        $this->filter = new ReactJsxFilter($jsxBin, $nodeBin);
     }
 
-    public function testFilterLoad()
+    /**
+     * @param \Assetic\Filter\ReactJsxFilter $filter
+     */
+    protected function filterLoad(ReactJsxFilter $filter)
     {
         $prolog = "/** @jsx React.DOM */\n";
         $expected = $prolog . 'React.renderComponent(React.createElement(HelloMessage, {name: "John"}), mountNode);';
         $asset = new StringAsset($prolog . 'React.renderComponent(<HelloMessage name="John" />, mountNode);');
         $asset->load();
-        $this->filter->filterLoad($asset);
+        $filter->filterLoad($asset);
 
         $this->assertEquals($expected, $this->clean($asset->getContent()));
+    }
+
+    public function testGlobalJsxBin()
+    {
+        $filter = new ReactJsxFilter($this->jsxBin, $this->nodeBin);
+        $this->filterLoad($filter);
+    }
+
+    public function testLocalJsxBin()
+    {
+        $filter = new ReactJsxFilter('/non/existent/jsx', $this->nodeBin, array(
+            __DIR__ . '/../../../../node_modules',
+        ));
+        $this->filterLoad($filter);
     }
 
     private function clean($js)


### PR DESCRIPTION
Tests pass? **Yes**

We had a situation where the JSX compiler was installed in different locations on different servers (one used the standard `/usr/bin/jsx` symlinked to `/usr/local/lib/node_modules/.bin/jsx` whilst the other used `%kernel.root_dir%/../node_modules` due to limitations).

I thought an option to search through the paths defined for `node_modules` similar to the Less filter was cleaner than a different parameter or environmental variable for each machine.

It's certainly future-proof for us by predicting common installation paths, thoughts?
