### PR TITLE
AssetFactory::createAsset() now generates asset name before initialize "root" option by default

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -172,6 +172,10 @@ class AssetFactory
             $options['debug'] = $this->debug;
         }
 
+        if (!isset($options['name'])) {
+            $options['name'] = $this->generateAssetName($inputs, $filters, $options);
+        }
+
         if (!isset($options['root'])) {
             $options['root'] = array($this->root);
         } else {
@@ -180,10 +184,6 @@ class AssetFactory
             }
 
             $options['root'][] = $this->root;
-        }
-
-        if (!isset($options['name'])) {
-            $options['name'] = $this->generateAssetName($inputs, $filters, $options);
         }
 
         $asset = $this->createAssetCollection(array(), $options);


### PR DESCRIPTION
I'm using Assetic in my project not using Symfony along document, then I have found a small problem about AssetFactory::generateAssetName().

This is example:

```php
<?php
// test.php

require __DIR__ . '/vendor/autoload.php';

$af = new \Assetic\Factory\AssetFactory(__DIR__);
$am = new \Assetic\Factory\LazyAssetManager($af);
$am->setLoader('php', new \Assetic\Factory\Loader\FunctionCallsFormulaLoader($af));
$am->addResource(new \Assetic\Factory\Resource\FileResource(__FILE__), 'php');

$writer = new \Assetic\AssetWriter(__DIR__);
$writer->writeManagerAssets($am);

assetic_init($af);

?>

<script src="<?= assetic_javascripts('my_script.js') ?>"></script>
```

Above code outputs like this:

```
<script src="js/d488990.js"></script>
```

But generated javascript's file name was not `js/d488990.js` but `js/2d92dd2.js`.
It because of AssetFactory::generateAssetName() called by assetic_javascripts sets `root` option factory has by default, but called by FunctionCallsFormulaLoader is not.