### PR TITLE
Adding a ; between the dumped files

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -151,7 +151,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
             $parts[] = $asset->dump($additionalFilter);
         }
 
-        return implode("\n", $parts);
+        return implode("\n;", $parts);
     }
 
     public function getContent()


### PR DESCRIPTION
 will allow files that don't end properly or with a semicolon to be combined without error.