### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,40 @@
 language: php
 
+addons:
+    packages:
+        - jpegoptim
+        - libjpeg-progs
+        - optipng
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 php:
     - 5.3
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
     - hhvm
 
 matrix:
     allow_failures:
         - php: hhvm
+        - php: 7.0
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+        - php: 5.6
+          env: DEPENDENCIES=dev
 
 before_script:
     # php deps
     - composer self-update
-    - composer install --dev
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - composer update $COMPOSER_FLAGS
 
     # node deps
     - npm install uglify-js@1 && mkdir -p vendor/uglifyjs && mv node_modules vendor/uglifyjs
@@ -38,7 +58,6 @@ before_script:
     - bundle install
 
     # other deps
-    - sudo apt-get install jpegoptim libjpeg-progs optipng
 
     - wget -q http://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip && unzip dartsdk-linux-x64-release.zip && mv dart-sdk vendor
     - export DART_BIN=vendor/dart-sdk/bin/dart2js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 addons:
-    packages:
-        - jpegoptim
-        - libjpeg-progs
-        - optipng
+    apt:
+        packages:
+            - jpegoptim
+            - libjpeg-progs
+            - optipng
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "kriswallsmith/assetic",
-    "minimum-stability": "dev",
     "description": "Asset Management for PHP",
     "keywords": [ "assets", "compression", "minification" ],
     "homepage": "https://github.com/kriswallsmith/assetic",
@@ -21,15 +20,15 @@
         "phpunit/phpunit": "~4",
         "twig/twig": "~1.6",
         "leafo/lessphp": "*",
-        "leafo/scssphp": "*",
+        "leafo/scssphp": "*@dev",
         "ptachoire/cssembed": "*",
-        "leafo/scssphp-compass": "*",
+        "leafo/scssphp-compass": "*@dev",
 
         "cssmin/cssmin": "*",
         "mrclay/minify": "*",
         "kamicane/packager": "*",
         "joliclic/javascript-packer": "*",
-        "patchwork/jsqueeze": "~1.0",
+        "patchwork/jsqueeze": "~1.0|~2.0",
         "psr/log": "~1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4",
-        "twig/twig": "~1.6",
-        "leafo/lessphp": "*",
+        "twig/twig": "~1.8",
+        "leafo/lessphp": "^0.3.7",
         "leafo/scssphp": "*@dev",
         "ptachoire/cssembed": "*",
         "leafo/scssphp-compass": "*@dev",

--- a/tests/Assetic/Test/Filter/JSqueezeFilterTest.php
+++ b/tests/Assetic/Test/Filter/JSqueezeFilterTest.php
@@ -21,7 +21,7 @@ class JSqueezeFilterTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('JSqueeze')) {
+        if (!class_exists('JSqueeze') && !class_exists('Patchwork\JSqueeze')) {
             $this->markTestSkipped('JSqueeze is not installed.');
         }
     }


### PR DESCRIPTION
- use the faster container-based infrastructure on Travis
- persist the composer cache between builds
- use stable dependencies by default (a job is kept running dev versions)
- test against lowest composer dependencies
- add testing on PHP 7