### PR TITLE
Add filter for PHP Libsass implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The core provides the following filters in the `Assetic\Filter` namespace:
  * `ReactJsxFilter`: compiles React JSX into JavaScript
  * `Sass\SassFilter`: parses SASS into CSS
  * `Sass\ScssFilter`: parses SCSS into CSS
+ * `SassphpFilter`: parses Sass into CSS using the sassphp bindings for Libsass
  * `ScssphpFilter`: parses SCSS using scssphp
  * `SeparatorFilter`: inserts a separator between assets to prevent merge failures
  * `SprocketsFilter`: Sprockets Javascript dependency management

--- a/src/Assetic/Filter/SassphpFilter.php
+++ b/src/Assetic/Filter/SassphpFilter.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2015 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Filter;
+
+use Assetic\Factory\AssetFactory;
+use Assetic\Asset\AssetInterface;
+use Assetic\Filter\DependencyExtractorInterface;
+use Assetic\Util\CssUtils;
+
+/**
+ * Compiles Sass to CSS.
+ *
+ * @author Mikey Clarke <mikey.clarke@me.com>
+ */
+class SassphpFilter implements DependencyExtractorInterface
+{
+    private $includePaths = array();
+    private $outputStyle;
+
+    public function filterLoad(AssetInterface $asset)
+    {
+        $sass = new \Sass();
+
+        $includePaths = array_merge(
+            array($asset->getSourceDirectory()),
+            $this->includePaths
+        );
+        $sass->setIncludePath(implode(':', $includePaths));
+
+        if ($this->outputStyle) {
+            $sass->setStyle($this->outputStyle);
+        }
+
+        $css = $sass->compile($asset->getContent());
+
+        $asset->setContent($css);
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+    }
+
+    public function setOutputStyle($outputStyle)
+    {
+        $this->outputStyle = $outputStyle;
+    }
+
+    public function setIncludePaths(array $paths)
+    {
+        $this->includePaths = $paths;
+    }
+
+    public function addIncludePath($path)
+    {
+        $this->includePaths[] = $path;
+    }
+
+    public function getChildren(AssetFactory $factory, $content, $loadPath = null)
+    {
+        $children = array();
+
+        $includePaths = $this->includePaths;
+        if (null !== $loadPath && !in_array($loadPath, $includePaths)) {
+            array_unshift($includePaths, $loadPath);
+        }
+
+        if (empty($includePaths)) {
+            return $children;
+        }
+
+        foreach (CssUtils::extractImports($content) as $reference) {
+            if ('.css' === substr($reference, -4)) {
+                continue;
+            }
+
+            // the reference may or may not have an extension or be a partial
+            if (pathinfo($reference, PATHINFO_EXTENSION)) {
+                $needles = array(
+                    $reference,
+                    $this->partialize($reference),
+                );
+            } else {
+                $needles = array(
+                    $reference . '.scss',
+                    $this->partialize($reference) . '.scss',
+                );
+            }
+
+            foreach ($includePaths as $includePath) {
+                foreach ($needles as $needle) {
+                    if (file_exists($file = $includePath . '/' . $needle)) {
+                        $child = $factory->createAsset($file, array(), array('root' => $includePath));
+                        $children[] = $child;
+                        $child->load();
+                        $children = array_merge(
+                            $children,
+                            $this->getChildren($factory, $child->getContent(), $includePath)
+                        );
+                    }
+                }
+            }
+        }
+
+        return $children;
+    }
+
+    private function partialize($reference)
+    {
+        $parts = pathinfo($reference);
+
+        if ('.' === $parts['dirname']) {
+            $partial = '_' . $parts['filename'];
+        } else {
+            $partial = $parts['dirname'] . DIRECTORY_SEPARATOR . '_' . $parts['filename'];
+        }
+
+        if (isset($parts['extension'])) {
+            $partial .= '.' . $parts['extension'];
+        }
+
+        return $partial;
+    }
+}

--- a/tests/Assetic/Test/Filter/SassphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/SassphpFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2015 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Factory\AssetFactory;
+use Assetic\Asset\FileAsset;
+use Assetic\Asset\StringAsset;
+use Assetic\Filter\SassphpFilter;
+
+class SassphpFilterTest extends \PHPUnit_Framework_TestCase
+{
+    private $filter;
+
+    protected function setUp()
+    {
+        if (!extension_loaded('sass')) {
+            $this->markTestSkipped('Sass extension is not installed');
+        }
+
+        $this->filter = new SassphpFilter();
+        $this->filter->setOutputStyle(\Sass::STYLE_COMPRESSED);
+    }
+
+    public function testCompilation()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/sassphp/example.scss');
+        $asset->load();
+
+        $expected = <<<EOF
+body{color:red}
+
+EOF;
+
+        $this->filter->filterLoad($asset);
+        $this->assertEquals($expected, $asset->getContent());
+    }
+
+    public function testOutputStyle()
+    {
+        $asset = new FileAsset(__DIR__.'/fixtures/sassphp/example.scss');
+        $asset->load();
+
+        $expected = <<<EOF
+body {
+  color: red;
+}
+
+EOF;
+
+        $this->filter->setOutputStyle(\Sass::STYLE_EXPANDED);
+        $this->filter->filterLoad($asset);
+
+        $this->assertEquals($expected, $asset->getContent());
+    }
+
+    public function testImports()
+    {
+        $asset = new StringAsset('@import "cheese";');
+        $asset->load();
+
+        $expected = <<<EOF
+body{color:blue}
+
+EOF;
+
+        $this->filter->addIncludePath(__DIR__ . '/fixtures/sassphp/includes');
+        $this->filter->filterLoad($asset);
+
+        $this->assertEquals($expected, $asset->getContent());
+    }
+
+    public function testExtractChildren()
+    {
+        $factory = new AssetFactory('');
+
+        $children = $this->filter->getChildren($factory, '@import "import";', __DIR__.'/fixtures/sassphp');
+
+        $this->assertCount(2, $children);
+    }
+
+    public function testExtractChildrenWithEmptyPath()
+    {
+        $factory = new AssetFactory(__DIR__.'/fixtures/sassphp');
+
+        $this->filter->addIncludePath(__DIR__.'/fixtures/sassphp');
+        $children = $this->filter->getChildren($factory, '@import "import";');
+
+        $this->assertCount(2, $children);
+    }
+}

--- a/tests/Assetic/Test/Filter/fixtures/sassphp/_child.scss
+++ b/tests/Assetic/Test/Filter/fixtures/sassphp/_child.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/tests/Assetic/Test/Filter/fixtures/sassphp/example.scss
+++ b/tests/Assetic/Test/Filter/fixtures/sassphp/example.scss
@@ -1,0 +1,5 @@
+$foo: red;
+
+body {
+    color: $foo;
+}

--- a/tests/Assetic/Test/Filter/fixtures/sassphp/import.scss
+++ b/tests/Assetic/Test/Filter/fixtures/sassphp/import.scss
@@ -1,0 +1,5 @@
+@import 'child';
+
+body {
+    background-color: blue;
+}

--- a/tests/Assetic/Test/Filter/fixtures/sassphp/includes/_cheese.scss
+++ b/tests/Assetic/Test/Filter/fixtures/sassphp/includes/_cheese.scss
@@ -1,0 +1,3 @@
+body {
+    color: blue;
+}


### PR DESCRIPTION
Requires the [sassphp](https://github.com/sensational/sassphp) extension, not sure where to document that.

I’m also not sure about the name given that there’s already `Sass\SassFilter`, `Sass\ScssFilter`, and `ScssphpFilter`, but I was worried that `LibsassFilter` wouldn’t be obvious enough for those who aren’t aware of that project.