### PR TITLE
Fix the compatibility with Twig 2

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticFilterFunction.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterFunction.php
@@ -15,7 +15,7 @@ class AsseticFilterFunction extends \Twig_SimpleFunction
 {
     public function __construct($name, $options = array())
     {
-        parent::__construct($name, '\Assetic\Extension\Twig\AsseticFilterInvoker::invoke', array_merge($options, array(
+        parent::__construct($name, null, array_merge($options, array(
             'needs_environment' => false,
             'needs_context' => false,
             'node_class' => '\Assetic\Extension\Twig\AsseticFilterNode',


### PR DESCRIPTION
I tried to trick Twig previously to win named arguments on the function, but Twig 2 has a callable typehint for the function callable and the method is not static.

This will disable the support of named arguments again (which was already not supported before #751) so that it actually works with Twig 2. Support for named arguments in such functions will have to wait for a later refactoring.