### PR TITLE
Fix commentless filter #758

### DIFF
--- a/src/Assetic/Util/Analyzer/AnalyzerState.php
+++ b/src/Assetic/Util/Analyzer/AnalyzerState.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Util\Analyzer;
+
+/**
+ * State of string analyzer
+ *
+ * @author Alex Ash <streamprop@gmail.com>
+ */
+class AnalyzerState
+{
+    private $type;
+    private $regexp;
+    private $token;
+    private $states;
+    private $unprocessed;
+
+    /**
+     * Create AnalyzerState
+     *
+     * Regexp should contain three named groups:
+     *  - 'processed' should contain pattern for the current state
+     *  - 'token' should contain pattern for transition from current state to next
+     *  - 'unprocessed' should contain pattern for unprocessed piece of string (may contain token)
+     *
+     * @param string          $type   - type of state (ex. 'comment', 'string', 'general', etc)
+     * @param string          $regexp - regexp to match against analyzing string
+     * @param AnalyzerState[] $states - array of token => state mappings, used to move between states
+     */
+    public function __construct($type, $regexp, array $states = array())
+    {
+        $this->type = $type;
+        $this->regexp = $regexp;
+        $this->states = $states;
+        $this->clean();
+    }
+
+    private function clean()
+    {
+        $this->token = null;
+        $this->unprocessed = null;
+    }
+
+    /**
+     * Define state links
+     *
+     * @param array $states - array of token => state mappings, used to move between states
+     *
+     * @return void
+     */
+    public function setStates(array $states)
+    {
+        $this->states = $states;
+    }
+
+    /**
+     * Add state link
+     *
+     * @param string $token
+     * @param AnalyzerState $state
+     *
+     * @return void
+     */
+    public function addState($token, $state)
+    {
+        $this->states[$token] = $state;
+    }
+
+    /**
+     * Get current state type
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get next state after processing string part
+     *
+     * @return AnalyzerState|null
+     */
+    public function getNextState()
+    {
+        return array_key_exists($this->token, $this->states)
+            ? $this->states[$this->token]
+            : null;
+    }
+
+    /**
+     * Get unprocessed part of the string
+     *
+     * @return string
+     */
+    public function getUnprocessed()
+    {
+        return $this->unprocessed;
+    }
+
+    /**
+     * Process string using regexp setted
+     *
+     * If called in strict mode and regexp doesn't match against string, exception is throwed,
+     * else the whole string is returned
+     *
+     * @param string $string - string to process
+     * @param bool   $strict - mode of processing
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function process($string, $strict = false)
+    {
+        $this->clean();
+        if(!preg_match($this->regexp, $string, $matches)) {
+            if ($strict) {
+                throw new \Exception("Cannot match pattern [{$this->regexp}] against string [$string]");
+            }
+
+            return $string;
+        }
+
+        $part = $matches['processed'];
+        $this->token = array_key_exists('token', $matches) ? $matches['token'] : null;
+        $this->unprocessed = array_key_exists('unprocessed', $matches) ? $matches['unprocessed'] : null;
+
+        return $part;
+    }
+}

--- a/src/Assetic/Util/Analyzer/CssAnalyzer.php
+++ b/src/Assetic/Util/Analyzer/CssAnalyzer.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Util\Analyzer;
+
+/**
+ * CSS analyzer
+ *
+ * @author Alex Ash <streamprop@gmail.com>
+ */
+class CssAnalyzer
+{
+    protected $general = '/^(?<processed>.*?\R*)(?<unprocessed>(?<token>\'|"|\/\*)(.*))?$/su';
+    protected $quoted = array(
+        array(
+            'begin'  => "'",
+            'end'    => "'",
+            'regexp' => '/^(?<processed>\'(.{0}|.*?[^\\\\])(?<token>\'))(?<unprocessed>.*)$/su',
+        ),
+        array(
+            'begin'  => '"',
+            'end'    => '"',
+            'regexp' => '/^(?<processed>"(.{0}|.*?[^\\\\])(?<token>"))(?<unprocessed>.*)$/su',
+        ),
+    );
+    protected $comment = array(
+        array(
+            'begin'  => '/*',
+            'end'    => '*/',
+            'regexp' => '/^(?<processed>\/\*.*?(?<token>\*\/))(?<unprocessed>.*)$/su',
+        ),
+    );
+    protected $state;
+    protected $css;
+
+    /**
+     * Create analyzer for CSS
+     *
+     * @param string $css
+     */
+    public function __construct($css)
+    {
+        $this->css = $css;
+        $this->state = new AnalyzerState('general', $this->general);
+
+        foreach ($this->quoted as $quotedItem) {
+            $state = new AnalyzerState('quoted', $quotedItem['regexp'], array($quotedItem['end'] => $this->state));
+            $this->state->addState($quotedItem['begin'], $state);
+        }
+
+        foreach ($this->comment as $commentItem) {
+            $state = new AnalyzerState('comment', $commentItem['regexp'], array($commentItem['end'] => $this->state));
+            $this->state->addState($commentItem['begin'], $state);
+        }
+    }
+
+    /**
+     * Shows whether analyzer has more steps to pass
+     *
+     * @return bool
+     */
+    public function hasSteps()
+    {
+        return !is_null($this->css);
+    }
+
+    /**
+     * Make one analyzer step
+     *
+     * Returns type and contents of analyzed part of CSS
+     *
+     * @return array - ['type' => 'typename', 'part' => 'analyzed_part']
+     */
+    public function step()
+    {
+        $type = $this->state->getType();
+        $part = $this->state->process($this->css);
+
+        $this->css = $this->state->getUnprocessed();
+        $this->state = $this->state->getNextState();
+
+        return array('type' => $type, 'part' => $part);
+    }
+}

--- a/src/Assetic/Util/Analyzer/LessAnalyzer.php
+++ b/src/Assetic/Util/Analyzer/LessAnalyzer.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Util\Analyzer;
+
+/**
+ * LESS analyzer
+ *
+ * @author Alex Ash <streamprop@gmail.com>
+ */
+class LessAnalyzer extends CssAnalyzer
+{
+    protected $general = '/^(?<processed>.*?\R*)(?<unprocessed>(?<token>\'|"|\/\*|\/\/)(.*))?$/su';
+    protected $comment = array(
+        array(
+            'begin'  => '/*',
+            'end'    => '*/',
+            'regexp' => '/^(?<processed>\/\*.*?(?<token>\*\/))(?<unprocessed>.*)$/su',
+        ),
+        array(
+            'begin'  => '//',
+            'end'    => '',
+            'regexp' => '/^(?<processed>\/\/.*?)(?<token>.{0})(?<unprocessed>\R.*)$/su',
+        ),
+    );
+}

--- a/src/Assetic/Util/LessUtils.php
+++ b/src/Assetic/Util/LessUtils.php
@@ -21,4 +21,6 @@ abstract class LessUtils extends CssUtils
     const REGEX_IMPORTS         = '/@import(?:-once)? (?:\([a-z]*\) )?(?:url\()?(\'|"|)(?P<url>[^\'"\)\n\r]*)\1\)?;?/';
     const REGEX_IMPORTS_NO_URLS = '/@import(?:-once)? (?:\([a-z]*\) )?(?!url\()(\'|"|)(?P<url>[^\'"\)\n\r]*)\1;?/';
     const REGEX_COMMENTS        = '/((?:\/\*[^*]*\*+(?:[^\/][^*]*\*+)*\/)|\/\/[^\n]+)/';
+
+    const ANALYZER = '\Assetic\Util\Analyzer\LessAnalyzer';
 }

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -86,10 +86,10 @@ EOF;
 
     public function testCompassExtensionCanBeDisabled()
     {
-        $this->setExpectedException(
+        $this->setExpectedExceptionRegExp(
             "Exception",
-            "Undefined mixin box-shadow: failed at `@include box-shadow(10px "
-            ."10px 8px red);` line: 4"
+            preg_quote("/Undefined mixin box-shadow: failed at `@include box-shadow(10px 10px 8px red);`").
+            ".*?".preg_quote(" line 4/")
         );
 
         $asset = new FileAsset(__DIR__.'/fixtures/sass/main_compass.scss');

--- a/tests/Assetic/Test/Util/Analyzer/AnalyzerStateTest.php
+++ b/tests/Assetic/Test/Util/Analyzer/AnalyzerStateTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Util\Analyzer;
+
+use Assetic\Util\Analyzer\AnalyzerState;
+
+class AnalyzerStateTest extends \PHPUnit_Framework_TestCase
+{
+    protected $general = '/^(?<processed>.*?\R*)(?<unprocessed>(?<token>\'|"|\/\*)(.*))?$/su';
+    protected $quoted = array(
+        array(
+            'begin'  => "'",
+            'end'    => "'",
+            'regexp' => '/^(?<processed>\'(.{0}|.*?[^\\\\])(?<token>\'))(?<unprocessed>.*)$/su',
+        ),
+        array(
+            'begin'  => '"',
+            'end'    => '"',
+            'regexp' => '/^(?<processed>"(.{0}|.*?[^\\\\])(?<token>"))(?<unprocessed>.*)$/su',
+        ),
+    );
+    protected $comment = array(
+        array(
+            'begin'  => '/*',
+            'end'    => '*/',
+            'regexp' => '/^(?<processed>\/\*.*?(?<token>\*\/))(?<unprocessed>.*)$/su',
+        ),
+    );
+    protected $state;
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->state = new AnalyzerState('general', $this->general);
+
+        foreach ($this->quoted as $quotedItem) {
+            $state = new AnalyzerState('quoted', $quotedItem['regexp'], array($quotedItem['end'] => $this->state));
+            $this->state->addState($quotedItem['begin'], $state);
+        }
+
+        foreach ($this->comment as $commentItem) {
+            $state = new AnalyzerState('comment', $commentItem['regexp'], array($commentItem['end'] => $this->state));
+            $this->state->addState($commentItem['begin'], $state);
+        }
+    }
+
+    public function testProcessSingleState()
+    {
+        $state = $this->state;
+        $string = ".foo {display: block;}";
+
+        $result = $state->process($string);
+
+        $this->assertEquals($string, $result);
+        $this->assertNull($state->getUnprocessed());
+        $this->assertNull($state->getNextState());
+    }
+
+    public function testProcessSeveralStates()
+    {
+        $state = $this->state;
+        $unprocessed = ".foo /* comment */ {display: block;}";
+        $types = array();
+        $values = array();
+        $expectedTypes = array('general', 'comment', 'general');
+        $expectedValues = array('.foo ', '/* comment */', ' {display: block;}');
+
+        do {
+            $types[] = $state->getType();
+            $values[] = $state->process($unprocessed);
+            $unprocessed = $state->getUnprocessed();
+        } while ($state = $state->getNextState());
+
+        $this->assertEquals($expectedTypes, $types);
+        $this->assertEquals($expectedValues, $values);
+    }
+
+    public function testProcessStrict()
+    {
+        $this->setExpectedExceptionRegExp(
+            "Exception",
+            "/Cannot match pattern \[.*?\] against string \[.*?\]/su"
+        );
+
+        $state = $this->state;
+        $string = ".foo '{display: block;}";
+
+        $state->process($string, true);
+        $unprocessed = $state->getUnprocessed();
+        $state->getNextState()->process($unprocessed, true);
+    }
+}

--- a/tests/Assetic/Test/Util/Analyzer/CssAnalyzerTest.php
+++ b/tests/Assetic/Test/Util/Analyzer/CssAnalyzerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Assetic package, an OpenSky project.
+ *
+ * (c) 2010-2014 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Assetic\Test\Util\Analyzer;
+
+use Assetic\Util\Analyzer\CssAnalyzer;
+
+class CssAnalyzerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHasStepsContentNotNull()
+    {
+        $analyzer = new CssAnalyzer("some content");
+
+        $has = $analyzer->hasSteps();
+
+        $this->assertTrue($has);
+    }
+
+    public function testHasStepsNullContent()
+    {
+        $analyzer = new CssAnalyzer(null);
+
+        $has = $analyzer->hasSteps();
+
+        $this->assertFalse($has);
+    }
+
+    public function testStepSingleState()
+    {
+        $content = ".foo {display: block;}";
+        $analyzer = new CssAnalyzer($content);
+
+        $result = $analyzer->step();
+
+        $this->assertEquals('general', $result['type']);
+        $this->assertEquals($content, $result['part']);
+        $this->assertFalse($analyzer->hasSteps());
+    }
+
+    public function testStepSeveralStates()
+    {
+        $content = ".foo /* comment */ {display: block;}";
+        $analyzer = new CssAnalyzer($content);
+        $types = array();
+        $parts = array();
+        $expectedTypes = array('general', 'comment', 'general');
+        $expectedParts = array('.foo ', '/* comment */', ' {display: block;}');
+
+        while ($analyzer->hasSteps()) {
+            $step = $analyzer->step();
+            $types[] = $step['type'];
+            $parts[] = $step['part'];
+        }
+
+        $this->assertEquals($expectedTypes, $types);
+        $this->assertEquals($expectedParts, $parts);
+    }
+}

--- a/tests/Assetic/Test/Util/CssUtilsTest.php
+++ b/tests/Assetic/Test/Util/CssUtilsTest.php
@@ -49,7 +49,20 @@ CSS;
 
     public function testFilterCommentless()
     {
-        $content = 'A/*B*/C/*D*/E';
+        $content = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import "sprites/*.png";
+/* some comment */
+.foo {font-family: /*"*/"*/any";}
+
+EOF;
+        $expected = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import "sprites/*.png";
+
+.foo {font-family: "*/any";}
+
+EOF;
 
         $filtered = '';
         $result = CssUtils::filterCommentless($content, function ($part) use (&$filtered) {
@@ -58,7 +71,7 @@ CSS;
             return $part;
         });
 
-        $this->assertEquals('ACE', $filtered);
+        $this->assertEquals($expected, $filtered);
         $this->assertEquals($content, $result);
     }
 }

--- a/tests/Assetic/Test/Util/LessUtilsTest.php
+++ b/tests/Assetic/Test/Util/LessUtilsTest.php
@@ -77,7 +77,31 @@ EOF;
 
     public function testFilterCommentlessLess()
     {
-        $content = "ACE // foo /* bar */\nbla";
+        $content = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import 'any//file.ico';
+@import "sprites/*.png";
+/* some comment */
+// inline comment
+/* multi-line
+// comment */.finished {color: red;}
+.foo {color: green;}// /* inline comment 2
+#shown {color: /*red*/blue;}
+.bar {font-family: /*"*/"*/any";}
+
+EOF;
+        $expected = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import 'any//file.ico';
+@import "sprites/*.png";
+
+
+.finished {color: red;}
+.foo {color: green;}
+#shown {color: blue;}
+.bar {font-family: "*/any";}
+
+EOF;
 
         $filtered = '';
         $result = LessUtils::filterCommentless($content, function ($part) use (&$filtered) {
@@ -86,7 +110,7 @@ EOF;
             return $part;
         });
 
-        $this->assertEquals("ACE \nbla", $filtered);
+        $this->assertEquals($expected, $filtered);
         $this->assertEquals($content, $result);
     }
 

--- a/tests/Assetic/Test/Util/LessUtilsTest.php
+++ b/tests/Assetic/Test/Util/LessUtilsTest.php
@@ -49,7 +49,20 @@ CSS;
 
     public function testFilterCommentless()
     {
-        $content = 'A/*B*/C/*D*/E';
+        $content = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import "sprites/*.png";
+/* some comment */
+.foo {font-family: /*"*/"*/any";}
+
+EOF;
+        $expected = <<<EOF
+@import 'some/*-dir-*/file.jpg';
+@import "sprites/*.png";
+
+.foo {font-family: "*/any";}
+
+EOF;
 
         $filtered = '';
         $result = LessUtils::filterCommentless($content, function ($part) use (&$filtered) {
@@ -58,7 +71,7 @@ CSS;
             return $part;
         });
 
-        $this->assertEquals('ACE', $filtered);
+        $this->assertEquals($expected, $filtered);
         $this->assertEquals($content, $result);
     }
 


### PR DESCRIPTION
This fixes issue #758 with CSS and also LESS filterCommentless.
Also broken test ScssphpFilterTest::testCompassExtensionCanBeDisabled fixed.

Possibly it worth moving from regexps to lexers/parsers for language processing (CSS, LESS etc.) in future.
