### PR TITLE
Update SeparatorFilter.php

### DIFF
--- a/src/Assetic/Filter/SeparatorFilter.php
+++ b/src/Assetic/Filter/SeparatorFilter.php
@@ -42,6 +42,6 @@ class SeparatorFilter implements FilterInterface
 
     public function filterDump(AssetInterface $asset)
     {
-        $asset->setContent($asset->getContent() . $this->separator);
+        $asset->setContent($this->separator . $asset->getContent());
     }
 }

--- a/tests/Assetic/Test/Filter/SeparatorFilterTest.php
+++ b/tests/Assetic/Test/Filter/SeparatorFilterTest.php
@@ -27,6 +27,6 @@ class SeparatorFilterTest extends \PHPUnit_Framework_TestCase
         $filter = new SeparatorFilter('+');
         $filter->filterDump($asset);
 
-        $this->assertEquals('foobar+', $asset->getContent());
+        $this->assertEquals('+foobar', $asset->getContent());
     }
 }


### PR DESCRIPTION
Appending the separator to the end of the file will not work in cases such as a javascript file that ends in a line comment ( "//" ) with no trailing newline. The separator will be commented out. The last line of a file is a common place to put a comment containing a sourcemap for minified JS.

Rather than make assumptions about whether the user means for any separator to be preceded by a newline, or for the default separator to be '\n;', other libraries that do this kind of thing, such as jsqueeze, simply put the separator at the beginning of the file, where it cannot be preceded by a line comment.
