### PR TITLE
Avoid using Twig_Environment::getFunction to identify Assetic functions

### DIFF
--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -70,27 +70,25 @@ class TwigFormulaLoader implements FormulaLoaderInterface
                     'vars'    => $node->getAttribute('vars'),
                 ),
             );
-        } elseif ($node instanceof \Twig_Node_Expression_Function) {
+        } elseif ($node instanceof AsseticFilterNode) {
             $name = $node->getAttribute('name');
 
-            if ($this->twig->getFunction($name) instanceof AsseticFilterFunction) {
-                $arguments = array();
-                foreach ($node->getNode('arguments') as $argument) {
-                    $arguments[] = eval('return '.$this->twig->compile($argument).';');
-                }
-
-                $invoker = $this->twig->getExtension('Assetic\\Extension\\Twig\\AsseticExtension')->getFilterInvoker($name);
-
-                $inputs  = isset($arguments[0]) ? (array) $arguments[0] : array();
-                $filters = $invoker->getFilters();
-                $options = array_replace($invoker->getOptions(), isset($arguments[1]) ? $arguments[1] : array());
-
-                if (!isset($options['name'])) {
-                    $options['name'] = $invoker->getFactory()->generateAssetName($inputs, $filters, $options);
-                }
-
-                $formulae[$options['name']] = array($inputs, $filters, $options);
+            $arguments = array();
+            foreach ($node->getNode('arguments') as $argument) {
+                $arguments[] = eval('return '.$this->twig->compile($argument).';');
             }
+
+            $invoker = $this->twig->getExtension('Assetic\Extension\Twig\AsseticExtension')->getFilterInvoker($name);
+
+            $inputs  = isset($arguments[0]) ? (array) $arguments[0] : array();
+            $filters = $invoker->getFilters();
+            $options = array_replace($invoker->getOptions(), isset($arguments[1]) ? $arguments[1] : array());
+
+            if (!isset($options['name'])) {
+                $options['name'] = $invoker->getFactory()->generateAssetName($inputs, $filters, $options);
+            }
+
+            $formulae[$options['name']] = array($inputs, $filters, $options);
         }
 
         foreach ($node as $child) {


### PR DESCRIPTION
As of Assetic 1.3.0, the Twig functions are using a special node class, which can be used to identify them instead.
The `getFunction` method is intended to be marked as an internal one in https://github.com/twigphp/Twig/pull/1889
