### PR TITLE
Allow composer to use http (fixes travis)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "files": [ "src/functions.php" ]
     },
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "secure-http": false
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This PR allows packages to be downloaded over http. 

This is needed because of [secure-http](https://getcomposer.org/doc/06-config.md#secure-http) was introduced in composer.
