### PR TITLE
Closure Api added default language to ensure compilation

### DIFF
--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -40,6 +40,7 @@ class CompilerApiFilter extends BaseCompilerFilter
             'js_code'       => $asset->getContent(),
             'output_format' => 'json',
             'output_info'   => 'compiled_code',
+            'language'      => self::LANGUAGE_ECMASCRIPT3,
         );
 
         if (null !== $this->compilationLevel) {


### PR DESCRIPTION
This PR fixes the failing CompilerApiFilterTest.

It seems that the closure compiler API requires a language to be set to be able to return compiled code. According to the [language docs](https://developers.google.com/closure/compiler/docs/api-ref#language) it would default to 'ECMASCRIPT3' but this seems not to be the case that is why setting this as the default fixes the failing test.
