### PR TITLE
Set the correct file extension if one package includes another

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -196,7 +196,11 @@ class AssetFactory
                 $asset->add(call_user_func_array(array($this, 'createAsset'), $input));
             } else {
                 $asset->add($this->parseInput($input, $options));
-                $extensions[pathinfo($input, PATHINFO_EXTENSION)] = true;
+                $extension = pathinfo($input, PATHINFO_EXTENSION);
+                if (($extension !== '') && ($extension !== null) && ($extension !== false)) {
+                    // filter out assets without extensions (like other packages)
+                    $extensions[$extension] = true;
+                }
             }
         }
 


### PR DESCRIPTION
I'm using assetic with the ZF(2)-Assetic module and came across a problem:
I've got a "base_js" package with jQuery, Bootstrap, etc in it. This gets combined and minified just fine.

I have another package (lets call it site_a_js) that should extend the "base_js" package with some more files. site_a_js should be a combined and minified version of alle JS files. Assetic combined and minified it, but didnt write the correct file extension ("js"). And because of this the AsseticBundle didnt include it correctly.

The bug is that you're trying to guess the extension out of the assets. This only works if all assets have the same extension (like ".js"). The package "base_js" doesnt have an extension, but you save it as an empty string into the $extensions variable. Now there are 2 extensions in it: "" and "js" which fails the extension-guessing.

This PR fixes that problem by testing if the parsed extension was valid.