### PR TITLE
Fix for Twig_Environment::tokenize() deprication since v1.27

### DIFF
--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -34,7 +34,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     public function load(ResourceInterface $resource)
     {
         try {
-            $tokens = $this->twig->tokenize($resource->getContent(), (string) $resource);
+            $tokens = $this->twig->tokenize(new \Twig_Source($resource->getContent(), (string) $resource));
             $nodes  = $this->twig->parse($tokens);
         } catch (\Exception $e) {
             if ($this->logger) {


### PR DESCRIPTION
Usage of the string content is depricated since Twig v1.27, Twig_Source object must be passed