### PR TITLE
Fixing deprecated notices from Twig 1.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,10 @@ before_script:
 
     # java deps
     - mkdir -p vendor/java
-    - wget http://dl.google.com/closure-compiler/compiler-latest.zip && unzip compiler-latest.zip -d vendor/java/compiler
+    - wget http://dl.google.com/closure-compiler/compiler-latest.zip && unzip compiler-latest.zip -d vendor/java/compiler && mv vendor/java/compiler/closure-compiler-*.jar vendor/java/compiler/compiler.jar
     - export CLOSURE_JAR=vendor/java/compiler/compiler.jar
-    - wget http://closure-stylesheets.googlecode.com/files/closure-stylesheets-20111230.jar && mv closure-stylesheets-20111230.jar vendor/java
-    - export GSS_JAR=vendor/java/closure-stylesheets-20111230.jar
+    - wget https://github.com/google/closure-stylesheets/releases/download/v1.4.0/closure-stylesheets.jar && mv closure-stylesheets.jar vendor/java
+    - export GSS_JAR=vendor/java/closure-stylesheets.jar
 #    TODO find the new URL for the cssembed JAR
 #    - wget https://github.com/downloads/nzakas/cssembed/cssembed-0.4.5.jar && mv cssembed-0.4.5.jar vendor/java
 #    - export CSSEMBED_JAR=vendor/java/cssembed-0.4.5.jar

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,21 @@
         "symfony/process": "~2.1|~3.0"
     },
     "conflict": {
-        "twig/twig": "<1.23"
+        "twig/twig": "<1.27"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "twig/twig": "~1.23|~2.0",
         "leafo/lessphp": "^0.3.7",
         "leafo/scssphp": "~0.1",
-        "ptachoire/cssembed": "~1.0",
-
-        "cssmin/cssmin": "3.0.1",
-        "mrclay/minify": "~2.2",
-        "kamicane/packager": "1.0",
-        "joliclic/javascript-packer": "1.1",
+        "meenie/javascript-packer": "^1.1",
+        "mrclay/minify": "<2.3",
+        "natxet/cssmin": "3.0.4",
         "patchwork/jsqueeze": "~1.0|~2.0",
-        "psr/log": "~1.0"
+        "phpunit/phpunit": "~4.8",
+        "psr/log": "~1.0",
+        "ptachoire/cssembed": "~1.0",
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "twig/twig": "~1.23|~2.0",
+        "yfix/packager": "dev-master"
     },
     "suggest": {
         "twig/twig": "Assetic provides the integration with the Twig templating engine",
@@ -53,34 +52,5 @@
         "branch-alias": {
             "dev-master": "1.4-dev"
         }
-    },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "cssmin/cssmin",
-                "version": "3.0.1",
-                "dist": { "url": "http://cssmin.googlecode.com/files/cssmin-v3.0.1.php", "type": "file" },
-                "autoload": { "classmap": [ "cssmin-v3.0.1.php" ] }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "kamicane/packager",
-                "version": "1.0",
-                "dist": { "url": "https://github.com/kamicane/packager/archive/1.0.zip", "type": "zip" },
-                "autoload": { "classmap": [ "." ] }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "joliclic/javascript-packer",
-                "version": "1.1",
-                "dist": { "url": "http://joliclic.free.fr/php/javascript-packer/telechargement.php?id=2&action=telecharger", "type": "zip" },
-                "autoload": { "classmap": [ "class.JavaScriptPacker.php" ] }
-            }
-        }
-    ]
+    }
 }

--- a/src/Assetic/Extension/Twig/AsseticFilterNode.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterNode.php
@@ -15,7 +15,7 @@ class AsseticFilterNode extends \Twig_Node_Expression_Function
 {
     protected function compileCallable(\Twig_Compiler $compiler)
     {
-        $compiler->raw(sprintf('$this->env->getExtension(\'assetic\')->getFilterInvoker(\'%s\')->invoke', $this->getAttribute('name')));
+        $compiler->raw(sprintf('$this->env->getExtension(\'Assetic\\Extension\\Twig\\AsseticExtension\')->getFilterInvoker(\'%s\')->invoke', $this->getAttribute('name')));
 
         $this->compileArguments($compiler);
     }

--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -34,7 +34,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     public function load(ResourceInterface $resource)
     {
         try {
-            $tokens = $this->twig->tokenize($resource->getContent(), (string) $resource);
+            $tokens = $this->twig->tokenize(new \Twig_Source($resource->getContent(), (string) $resource));
             $nodes  = $this->twig->parse($tokens);
         } catch (\Exception $e) {
             if ($this->logger) {
@@ -79,7 +79,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
                     $arguments[] = eval('return '.$this->twig->compile($argument).';');
                 }
 
-                $invoker = $this->twig->getExtension('assetic')->getFilterInvoker($name);
+                $invoker = $this->twig->getExtension('Assetic\\Extension\\Twig\\AsseticExtension')->getFilterInvoker($name);
 
                 $inputs  = isset($arguments[0]) ? (array) $arguments[0] : array();
                 $filters = $invoker->getFilters();

--- a/src/Assetic/Extension/Twig/TwigResource.php
+++ b/src/Assetic/Extension/Twig/TwigResource.php
@@ -32,7 +32,9 @@ class TwigResource implements ResourceInterface
     public function getContent()
     {
         try {
-            return $this->loader->getSource($this->name);
+            return method_exists($this->loader, 'getSourceContext')
+                ? $this->loader->getSourceContext($this->name)->getCode()
+                : $this->loader->getSource($this->name);
         } catch (\Twig_Error_Loader $e) {
             return '';
         }

--- a/tests/Assetic/Test/Extension/Twig/TwigResourceTest.php
+++ b/tests/Assetic/Test/Extension/Twig/TwigResourceTest.php
@@ -24,6 +24,11 @@ class TwigResourceTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidTemplateNameGetContent()
     {
+        if (!method_exists('Twig_LoaderInterface', 'getSource'))
+        {
+            $this->markTestSkipped('Twig_LoaderInterface does not have method getSource');
+        }
+
         $loader = $this->getMock('Twig_LoaderInterface');
         $loader->expects($this->once())
             ->method('getSource')

--- a/tests/Assetic/Test/Filter/AutoprefixerFilterTest.php
+++ b/tests/Assetic/Test/Filter/AutoprefixerFilterTest.php
@@ -46,7 +46,6 @@ CSS;
         $expected = <<<CSS
 a {
   display: -webkit-box;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }


### PR DESCRIPTION
Fix needed for https://github.com/symfony/assetic-bundle/pull/423 with small clean up in dev dependencies.