### PR TITLE
Add method to allow variable overrides when using the lessphp filter

### DIFF
--- a/src/Assetic/Filter/LessphpFilter.php
+++ b/src/Assetic/Filter/LessphpFilter.php
@@ -32,6 +32,7 @@ class LessphpFilter implements DependencyExtractorInterface
     private $preserveComments;
     private $customFunctions = array();
     private $options = array();
+    private $variables = array();
 
     /**
      * Lessphp Load Paths
@@ -77,6 +78,18 @@ class LessphpFilter implements DependencyExtractorInterface
     {
         $this->formatter = $formatter;
     }
+    
+    public function setVariables(array $variables)
+    {
+        foreach($variables as $name => $value) {
+            $this->addVariable($name, $value);
+        }
+    }
+
+    public function addVariable($name, $value)
+    {
+        $this->variables[$name] = $value;
+    }
 
     /**
      * @param boolean $preserveComments
@@ -111,6 +124,10 @@ class LessphpFilter implements DependencyExtractorInterface
         
         if (method_exists($lc, 'setOptions') && count($this->options) > 0 ) {
         	$lc->setOptions($this->options);
+        }
+        
+        if (!empty($this->variables)) {
+            $lc->setVariables($this->variables);
         }
 
         $asset->setContent($lc->parse($asset->getContent(), $this->presets));

--- a/tests/Assetic/Test/Filter/LessphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/LessphpFilterTest.php
@@ -98,6 +98,18 @@ EOF;
         $this->assertEquals($expected, $asset->getContent(), '->filterLoad() adds load paths to include paths');
     }
 
+    public function testSetVariables()
+    {
+        $filter = $this->filter;
+        $filter->setVariables(array('color' => 'red'));
+
+        $asset = new StringAsset("#test { color: @color; }");
+        $asset->load();
+        $filter->filterLoad($asset);
+
+        $this->assertContains('color: red', $asset->getContent(), 'Variables can be added');
+    }
+
     /**
      * @group integration
      */


### PR DESCRIPTION
Implements `setVariables()` and `setVariable()` methods in the Lessphpfilter class. 
The variables are passed through to the lessc class and can be used to override variable settings in parsed less files before compiled css output is generated.

Requested in ticket #808