### PR TITLE
Ignoring partial scss files (_*.scss) 

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -28,10 +28,21 @@ use Leafo\ScssPhp\Compiler;
 class ScssphpFilter implements DependencyExtractorInterface
 {
     private $compass = false;
+    private $ignorePartials = false;
     private $importPaths = array();
     private $customFunctions = array();
     private $formatter;
     private $variables = array();
+    
+    public function ignorePartial($enable = true)
+    {
+    	$this->ignorePartials = (Boolean) $enable;
+    }
+    
+    public function isPartialIgnored()
+    {
+    	return $this->ignorePartials;
+    }
 
     public function enableCompass($enable = true)
     {
@@ -88,6 +99,16 @@ class ScssphpFilter implements DependencyExtractorInterface
 
     public function filterLoad(AssetInterface $asset)
     {
+    	if($this->ignorePartials) {
+	        $path = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
+	        $file = basename($path);
+	        
+	        if(strrpos($file, '_', -strlen($file)) !== false) {
+	            $asset->setContent(" ");
+	            return;
+	        }
+    	}
+        
         $sc = new Compiler();
 
         if ($this->compass) {

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -36,12 +36,12 @@ class ScssphpFilter implements DependencyExtractorInterface
     
     public function ignorePartial($enable = true)
     {
-    	$this->ignorePartials = (Boolean) $enable;
+        $this->ignorePartials = (Boolean) $enable;
     }
     
     public function isPartialIgnored()
     {
-    	return $this->ignorePartials;
+        return $this->ignorePartials;
     }
 
     public function enableCompass($enable = true)
@@ -99,15 +99,15 @@ class ScssphpFilter implements DependencyExtractorInterface
 
     public function filterLoad(AssetInterface $asset)
     {
-    	if($this->ignorePartials) {
-	        $path = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
-	        $file = basename($path);
-	        
-	        if(strrpos($file, '_', -strlen($file)) !== false) {
-	            $asset->setContent(" ");
-	            return;
-	        }
-    	}
+        if($this->ignorePartials) {
+            $path = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
+            $file = basename($path);
+
+            if(strrpos($file, '_', -strlen($file)) !== false) {
+                $asset->setContent(" ");
+                return;
+            }
+        }
         
         $sc = new Compiler();
 

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -195,14 +195,14 @@ EOF;
     }
     
     public function testIgnorePartials() {
-    	$asset = new FileAsset(__DIR__.'/fixtures/sass/_include.scss');
-    	$asset->load();
-    	
-    	$filter = $this->getFilter();
-    	$filter->ignorePartial(true);
-    	$filter->filterLoad($asset);
-    	 
-    	$this->assertEquals(' ', $asset->getContent(), '->filterLoad() should ignore partial scss files');
+        $asset = new FileAsset(__DIR__.'/fixtures/sass/_include.scss');
+        $asset->load();
+
+        $filter = $this->getFilter();
+        $filter->ignorePartial(true);
+        $filter->filterLoad($asset);
+
+        $this->assertEquals(' ', $asset->getContent(), '->filterLoad() should ignore partial scss files');
     }
 
     // private

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -193,6 +193,17 @@ EOF;
 
         $this->assertContains('color: red', $asset->getContent(), 'Variables can be added');
     }
+    
+    public function testIgnorePartials() {
+    	$asset = new FileAsset(__DIR__.'/fixtures/sass/_include.scss');
+    	$asset->load();
+    	
+    	$filter = $this->getFilter();
+    	$filter->ignorePartial(true);
+    	$filter->filterLoad($asset);
+    	 
+    	$this->assertEquals(' ', $asset->getContent(), '->filterLoad() should ignore partial scss files');
+    }
 
     // private
 


### PR DESCRIPTION
Added a flag for the ScssphpFilter to ignore parsing of partial files by the filterLoad method.