### PR TITLE
Fix environment merge from server var

### DIFF
--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -51,6 +51,9 @@ abstract class BaseProcessFilter implements FilterInterface
     protected function mergeEnv(ProcessBuilder $pb)
     {
         foreach (array_filter($_SERVER, 'is_scalar') as $key => $value) {
+            if (preg_match('/^[a-z][a-z0-9_]*$/i', $key) === 0) {
+                continue;
+            }
             $pb->setEnv($key, $value);
         }
     }

--- a/tests/Assetic/Test/Filter/CompassFilterTest.php
+++ b/tests/Assetic/Test/Filter/CompassFilterTest.php
@@ -69,4 +69,24 @@ class CompassFilterTest extends FilterTestCase
 
         $this->assertContains('text-decoration', $asset->getContent());
     }
+
+    public function testEnvironment()
+    {
+        $_SERVER = [
+            'GOOD_ENV_VAR' => 'scalar',
+            'NOT_SCALAR_VAR' => [],
+            'good_minus_env_var' => 'scalar',
+            'bad-env-bar' => 'scalar',
+            '3_BAD_NUMBER_ENV_VAR' => 'scalar',
+            'BAD_$CHARACTER_ENV_VAR' => 'scalar',
+            'GOD_NUMBER_3_ENV_VAR' => 'scalar',
+        ];
+
+        $asset = new FileAsset(__DIR__.'/fixtures/compass/stylesheet.sass');
+        $asset->load();
+
+        $this->filter->filterLoad($asset);
+
+        $this->assertContains('.test-class', $asset->getContent());
+    }
 }

--- a/tests/Assetic/Test/Filter/CompassFilterTest.php
+++ b/tests/Assetic/Test/Filter/CompassFilterTest.php
@@ -72,15 +72,15 @@ class CompassFilterTest extends FilterTestCase
 
     public function testEnvironment()
     {
-        $_SERVER = [
+        $_SERVER = array(
             'GOOD_ENV_VAR' => 'scalar',
-            'NOT_SCALAR_VAR' => [],
+            'NOT_SCALAR_VAR' => array(),
             'good_minus_env_var' => 'scalar',
             'bad-env-bar' => 'scalar',
             '3_BAD_NUMBER_ENV_VAR' => 'scalar',
             'BAD_$CHARACTER_ENV_VAR' => 'scalar',
             'GOD_NUMBER_3_ENV_VAR' => 'scalar',
-        ];
+        );
 
         $asset = new FileAsset(__DIR__.'/fixtures/compass/stylesheet.sass');
         $asset->load();


### PR DESCRIPTION
Sometimes with PHP-FPM and Apache there is in the $_SERVER a key named "proxy-nokeepalive"
You can also define custom environment variables in your webserver and this variables will be passed to the global var $_SERVER (in Apache, try : SetEnv bad-name 1).

This environment variables could be named with a bad name for Linux/Windows environment variables.

In my webserver, when I use CompassFilter, the result is : 
```sh: 1: export: proxy-nokeepalive: bad variable name```

The BaseNodeFilter has the same problem (use the BaseProcessFilter::mergeEnv method)

This fix check the var names before to add it in the environment of the process.