### PR TITLE
Removed old Twig_TokenStream::getFilename call in AsseticTokenParser,…

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -113,7 +113,7 @@ class AsseticTokenParser extends \Twig_TokenParser
                 $attributes[$key] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
             } else {
                 $token = $stream->getCurrent();
-                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getSourceContext());
+                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getSourceContext()->getName());
             }
         }
 

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -113,7 +113,7 @@ class AsseticTokenParser extends \Twig_TokenParser
                 $attributes[$key] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
             } else {
                 $token = $stream->getCurrent();
-                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getFilename());
+                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getSourceContext());
             }
         }
 


### PR DESCRIPTION
… which occurred when an unexpected punctuation exception was thrown (throwing its own exception as a result). It was replaced with Twig_TokenStream::getSourceContext.

If you're using Twig 2 and you use 'unexpected punctuation', you'll get an exception about the call.