### PR TITLE
[CssRewriteFilter] Don't rewrite relative URLs beginning with hash (#)

### DIFF
--- a/src/Assetic/Filter/CssRewriteFilter.php
+++ b/src/Assetic/Filter/CssRewriteFilter.php
@@ -68,7 +68,11 @@ class CssRewriteFilter extends BaseCssFilter
         }
 
         $content = $this->filterReferences($asset->getContent(), function ($matches) use ($host, $path) {
-            if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
+            if (false !== strpos($matches['url'], '://')
+                || 0 === strpos($matches['url'], '//')
+                || 0 === strpos($matches['url'], 'data:')
+                || '#' === substr($matches['url'], 0, 1)
+            ) {
                 // absolute or protocol-relative or data uri
                 return $matches[0];
             }

--- a/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
+++ b/tests/Assetic/Test/Filter/CssRewriteFilterTest.php
@@ -61,6 +61,7 @@ class CssRewriteFilterTest extends \PHPUnit_Framework_TestCase
             array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', 'http://foo.com/bar.gif', 'http://foo.com/bar.gif'),
             array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', '/images/foo.gif', '/images/foo.gif'),
             array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', 'http://foo.com/images/foo.gif', 'http://foo.com/images/foo.gif'),
+            array('body { background: url(%s); }', 'css/body.css', 'css/build/main.css', '#foobar', '#foobar'),
 
             // IE AlphaImageLoader filter
             array('.fix { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\'%s\'); }', 'css/ie.css', 'css/build/ie.css', '../images/fix.png', '../../images/fix.png'),


### PR DESCRIPTION
I have some weird filters in my CSS files from external libraries, e.g. `filter: url(#shadow);` I think the CssRewriteFilter should not rewrite those, so I added an exclude for those cases.