### PR TITLE
Stop using deprecated node modules

### DIFF
--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -105,7 +105,6 @@ class LessFilter extends BaseNodeFilter implements DependencyExtractorInterface
     {
         static $format = <<<'EOF'
 var less = require('less');
-var sys  = require(process.binding('natives').util ? 'util' : 'sys');
 
 less.render(%s, %s, function(error, css) {
     if (error) {
@@ -114,9 +113,9 @@ less.render(%s, %s, function(error, css) {
     }
     try {
         if (typeof css == 'string') {
-            sys.print(css);
+            process.stdout.write(css);
         } else {
-            sys.print(css.css);
+            process.stdout.write(css.css);
         }
     } catch (e) {
         less.writeError(error);


### PR DESCRIPTION
The `sys` module became deprecated in node 0.4.x, and `util.print` in node 6.0.0. While you can still use `util.print`, it's best to make the code future proof and simply use `process.stdout.write()`.