### PR TITLE
Fix Google Closure API endpoint to HTTPS

### DIFF
--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -89,10 +89,10 @@ class CompilerApiFilter extends BaseCompilerFilter
             }
             $context = stream_context_create($contextOptions);
 
-            $response = file_get_contents('http://closure-compiler.appspot.com/compile', false, $context);
+            $response = file_get_contents('https://closure-compiler.appspot.com/compile', false, $context);
             $data = json_decode($response);
         } elseif (defined('CURLOPT_POST') && !in_array('curl_init', explode(',', ini_get('disable_functions')))) {
-            $ch = curl_init('http://closure-compiler.appspot.com/compile');
+            $ch = curl_init('https://closure-compiler.appspot.com/compile');
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded'));
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -96,6 +96,7 @@ class CompilerApiFilter extends BaseCompilerFilter
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded'));
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
             if (null !== $this->timeout) {


### PR DESCRIPTION
The HTTP endpoint of the Google Closure API doesn't seem reliable anymore. It has been (rightfully) moved to HTTPS (https://closure-compiler.appspot.com/compile).