### PR TITLE
Update for symfony/process v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: php
 
+env:
+  - CXX=g++-4.8
+
 addons:
     apt:
+        sources:
+            - ubuntu-toolchain-r-test
         packages:
             - jpegoptim
             - libjpeg-progs
             - optipng
+            - g++-4.8
 
 sudo: false
 
@@ -14,11 +20,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ matrix:
     allow_failures:
         - php: hhvm
         - php: 7.1
-    include:
-        - php: 5.3
-          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
-        - php: 5.6
-          env: DEPENDENCIES=dev
 
 before_script:
     # php deps

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4-dev"
+            "dev-symfony-process-4": "1.5-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.1",
-        "symfony/process": "~2.1|~3|~4"
+        "symfony/process": "~4"
     },
     "conflict": {
         "twig/twig": "<1.27"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.1",
-        "symfony/process": "~2.1|~3.0"
+        "symfony/process": "~2.1|~3|~4"
     },
     "conflict": {
         "twig/twig": "<1.27"

--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -11,7 +11,7 @@
 
 namespace Assetic\Filter;
 
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * An external process based filter which provides a way to set a timeout on the process.
@@ -35,11 +35,11 @@ abstract class BaseProcessFilter implements FilterInterface
      *
      * @param array $arguments An optional array of arguments
      *
-     * @return ProcessBuilder A new process builder
+     * @return Process A new process builder
      */
     protected function createProcessBuilder(array $arguments = array())
     {
-        $pb = new ProcessBuilder($arguments);
+        $pb = new Process($arguments);
 
         if (null !== $this->timeout) {
             $pb->setTimeout($this->timeout);
@@ -48,10 +48,14 @@ abstract class BaseProcessFilter implements FilterInterface
         return $pb;
     }
 
-    protected function mergeEnv(ProcessBuilder $pb)
+    protected function mergeEnv(Process $process)
     {
+        $env = $process->getEnv();
+
         foreach (array_filter($_SERVER, 'is_scalar') as $key => $value) {
-            $pb->setEnv($key, $value);
+            $env[$key] = $value;
         }
+
+        $process->setEnv($env);
     }
 }

--- a/src/Assetic/Filter/CleanCssFilter.php
+++ b/src/Assetic/Filter/CleanCssFilter.php
@@ -13,11 +13,12 @@ namespace Assetic\Filter;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
+use Symfony\Component\Process\Process;
 
 /**
  * CleanCss filter.
  *
- * @link https://github.com/jakubpawlowicz/clean-css
+ * @link   https://github.com/jakubpawlowicz/clean-css
  * @author Jakub Pawlowicz <http://JakubPawlowicz.com>
  */
 class CleanCssFilter extends BaseNodeFilter
@@ -47,8 +48,8 @@ class CleanCssFilter extends BaseNodeFilter
 
 
     /**
-     * @param string $cleanCssBin  Absolute path to the cleancss executable
-     * @param string $nodeBin      Absolute path to the folder containg node.js executable
+     * @param string $cleanCssBin Absolute path to the cleancss executable
+     * @param string $nodeBin     Absolute path to the folder containg node.js executable
      */
     public function __construct($cleanCssBin = '/usr/bin/cleancss', $nodeBin = null)
     {
@@ -58,6 +59,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Keep line breaks
+     *
      * @param bool $keepLineBreaks True to enable
      */
     public function setKeepLineBreaks($keepLineBreaks)
@@ -67,6 +69,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Remove all special comments
+     *
      * @param bool $removeSpecialComments True to enable
      */ // i.e.  /*! comment */
     public function setRemoveSpecialComments($removeSpecialComments)
@@ -76,14 +79,17 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Remove all special comments except the first one
+     *
      * @param bool $onlyKeepFirstSpecialComment True to enable
      */
     public function setOnlyKeepFirstSpecialComment($onlyKeepFirstSpecialComment)
     {
         $this->onlyKeepFirstSpecialComment = $onlyKeepFirstSpecialComment;
     }
+
     /**
      * Enables unsafe mode by assuming BEM-like semantic stylesheets (warning, this may break your styling!)
+     *
      * @param bool $semanticMerging True to enable
      */
     public function setSemanticMerging($semanticMerging)
@@ -93,6 +99,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * A root path to which resolve absolute @import rules
+     *
      * @param string $rootPath
      */
     public function setRootPath($rootPath)
@@ -102,14 +109,17 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable @import processing
+     *
      * @param bool $skipImport True to enable
      */
     public function setSkipImport($skipImport)
     {
         $this->skipImport = $skipImport;
     }
+
     /**
      * Per connection timeout when fetching remote @imports; defaults to 5 seconds
+     *
      * @param int $timeout
      */
     public function setTimeout($timeout)
@@ -119,6 +129,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable URLs rebasing
+     *
      * @param bool $skipRebase True to enable
      */
     public function setSkipRebase($skipRebase)
@@ -128,6 +139,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable restructuring optimizations
+     *
      * @param bool $skipRestructuring True to enable
      */
     public function setSkipRestructuring($skipRestructuring)
@@ -137,6 +149,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable shorthand compacting
+     *
      * @param bool $skipShorthandCompacting True to enable
      */
     public function setSkipShorthandCompacting($skipShorthandCompacting)
@@ -146,6 +159,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Enables building input's source map
+     *
      * @param bool $sourceMap True to enable
      */
     public function setSourceMap($sourceMap)
@@ -155,6 +169,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Enables inlining sources inside source maps
+     *
      * @param bool $sourceMapInlineSources True to enable
      */
     public function setSourceMapInlineSources($sourceMapInlineSources)
@@ -164,6 +179,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable advanced optimizations - selector & property merging, reduction, etc.
+     *
      * @param bool $skipAdvanced True to enable
      */
     public function setSkipAdvanced($skipAdvanced)
@@ -173,6 +189,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable properties merging based on their order
+     *
      * @param bool $skipAggresiveMerging True to enable
      */
     public function setSkipAggresiveMerging($skipAggresiveMerging)
@@ -182,6 +199,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable @import processing for specified rules
+     *
      * @param string $skipImportFrom
      */
     public function setSkipImportFrom($skipImportFrom)
@@ -191,6 +209,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Disable @media merging
+     *
      * @param bool $mediaMerging True to enable
      */
     public function setMediaMerging($mediaMerging)
@@ -200,6 +219,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Rounds to `N` decimal places. Defaults to 2. -1 disables rounding.
+     *
      * @param int $roundingPrecision
      */
     public function setRoundingPrecision($roundingPrecision)
@@ -209,6 +229,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Force compatibility mode (see https://github.com/jakubpawlowicz/clean-css/blob/master/README.md#how-to-set-compatibility-mode for advanced examples)
+     *
      * @param string $compatibility
      */
     public function setCompatibility($compatibility)
@@ -218,6 +239,7 @@ class CleanCssFilter extends BaseNodeFilter
 
     /**
      * Shows debug information (minification time & compression efficiency)
+     *
      * @param bool $debug True to enable
      */
     public function setDebug($debug)
@@ -227,7 +249,7 @@ class CleanCssFilter extends BaseNodeFilter
 
 
     /**
-     * @see Assetic\Filter\FilterInterface::filterLoad()
+     * @see FilterInterface::filterLoad()
      */
     public function filterLoad(AssetInterface $asset)
     {
@@ -237,96 +259,96 @@ class CleanCssFilter extends BaseNodeFilter
     /**
      * Run the asset through CleanCss
      *
-     * @see Assetic\Filter\FilterInterface::filterDump()
+     * @see FilterInterface::filterDump()
      */
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline = $this->nodeBin
             ? array($this->nodeBin, $this->cleanCssBin)
-            : array($this->cleanCssBin));
+            : array($this->cleanCssBin);
 
         if ($this->keepLineBreaks) {
-            $pb->add('--keep-line-breaks');
+            array_push($commandline, '--keep-line-breaks');
         }
 
         if ($this->compatibility) {
-            $pb->add('--compatibility ' .$this->compatibility);
+            array_push($commandline, '--compatibility ' . $this->compatibility);
         }
 
         if ($this->debug) {
-            $pb->add('--debug');
+            array_push($commandline, '--debug');
         }
 
         if ($this->rootPath) {
-            $pb->add('--root ' .$this->rootPath);
+            array_push($commandline, '--root ' . $this->rootPath);
         }
 
         if ($this->skipImport) {
-            $pb->add('--skip-import');
+            array_push($commandline, '--skip-import');
         }
 
         if ($this->timeout) {
-            $pb->add('--timeout ' .$this->timeout);
+            array_push($commandline, '--timeout ' . $this->timeout);
         }
 
         if ($this->roundingPrecision) {
-            $pb->add('--rounding-precision ' .$this->roundingPrecision);
+            array_push($commandline, '--rounding-precision ' . $this->roundingPrecision);
         }
 
         if ($this->removeSpecialComments) {
-            $pb->add('--s0');
+            array_push($commandline, '--s0');
         }
 
         if ($this->onlyKeepFirstSpecialComment) {
-            $pb->add('--s1');
+            array_push($commandline, '--s1');
         }
 
         if ($this->semanticMerging) {
-            $pb->add('--semantic-merging');
+            array_push($commandline, '--semantic-merging');
         }
 
         if ($this->skipAdvanced) {
-            $pb->add('--skip-advanced');
+            array_push($commandline, '--skip-advanced');
         }
 
         if ($this->skipAggresiveMerging) {
-            $pb->add('--skip-aggressive-merging');
+            array_push($commandline, '--skip-aggressive-merging');
         }
 
         if ($this->skipImportFrom) {
-            $pb->add('--skip-import-from ' .$this->skipImportFrom);
+            array_push($commandline, '--skip-import-from ' . $this->skipImportFrom);
         }
 
         if ($this->mediaMerging) {
-            $pb->add('--skip-media-merging');
+            array_push($commandline, '--skip-media-merging');
         }
 
         if ($this->skipRebase) {
-            $pb->add('--skip-rebase');
+            array_push($commandline, '--skip-rebase');
         }
 
         if ($this->skipRestructuring) {
-            $pb->add('--skip-restructuring');
+            array_push($commandline, '--skip-restructuring');
         }
 
         if ($this->skipShorthandCompacting) {
-            $pb->add('--skip-shorthand-compacting');
+            array_push($commandline, '--skip-shorthand-compacting');
         }
 
         if ($this->sourceMap) {
-            $pb->add('--source-map');
+            array_push($commandline, '--source-map');
         }
 
         if ($this->sourceMapInlineSources) {
-            $pb->add('--source-map-inline-sources');
+            array_push($commandline, '--source-map-inline-sources');
         }
         // input and output files
         $input = tempnam(sys_get_temp_dir(), 'input');
 
         file_put_contents($input, $asset->getContent());
-        $pb->add($input);
+        array_push($commandline, $input);
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/CoffeeScriptFilter.php
+++ b/src/Assetic/Filter/CoffeeScriptFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Compiles CoffeeScript into Javascript.
@@ -51,22 +52,22 @@ class CoffeeScriptFilter extends BaseNodeFilter
         $input = FilesystemUtils::createTemporaryFile('coffee');
         file_put_contents($input, $asset->getContent());
 
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline =$this->nodeBin
             ? array($this->nodeBin, $this->coffeeBin)
-            : array($this->coffeeBin));
+            : array($this->coffeeBin);
 
-        $pb->add('-cp');
+        array_push($commandline, '-cp');
 
         if ($this->bare) {
-            $pb->add('--bare');
+            array_push($commandline, '--bare');
         }
 
         if ($this->noHeader) {
-            $pb->add('--no-header');
+            array_push($commandline, '--no-header');
         }
 
-        $pb->add($input);
-        $proc = $pb->getProcess();
+        array_push($commandline, $input);
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/CssEmbedFilter.php
+++ b/src/Assetic/Filter/CssEmbedFilter.php
@@ -15,11 +15,12 @@ use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * CSSEmbed filter
  *
- * @link https://github.com/nzakas/cssembed
+ * @link   https://github.com/nzakas/cssembed
  * @author Maxime Thirouin <maxime.thirouin@gmail.com>
  */
 class CssEmbedFilter extends BaseProcessFilter implements DependencyExtractorInterface
@@ -81,50 +82,50 @@ class CssEmbedFilter extends BaseProcessFilter implements DependencyExtractorInt
 
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder(array(
+        $commandline = array(
             $this->javaPath,
             '-jar',
             $this->jarPath,
-        ));
+        );
 
         if (null !== $this->charset) {
-            $pb->add('--charset')->add($this->charset);
+            array_push($commandline, '--charset', $this->charset);
         }
 
         if ($this->mhtml) {
-            $pb->add('--mhtml');
+            array_push($commandline, '--mhtml');
         }
 
         if (null !== $this->mhtmlRoot) {
-            $pb->add('--mhtmlroot')->add($this->mhtmlRoot);
+            array_push($commandline, '--mhtmlroot', $this->mhtmlRoot);
         }
 
         // automatically define root if not already defined
         if (null === $this->root) {
             if ($dir = $asset->getSourceDirectory()) {
-                $pb->add('--root')->add($dir);
+                array_push($commandline, '--root', $dir);
             }
         } else {
-            $pb->add('--root')->add($this->root);
+            array_push($commandline, '--root', $this->root);
         }
 
         if ($this->skipMissing) {
-            $pb->add('--skip-missing');
+            array_push($commandline, '--skip-missing');
         }
 
         if (null !== $this->maxUriLength) {
-            $pb->add('--max-uri-length')->add($this->maxUriLength);
+            array_push($commandline, '--max-uri-length', $this->maxUriLength);
         }
 
         if (null !== $this->maxImageSize) {
-            $pb->add('--max-image-size')->add($this->maxImageSize);
+            array_push($commandline, '--max-image-size', $this->maxImageSize);
         }
 
         // input
-        $pb->add($input = FilesystemUtils::createTemporaryFile('cssembed'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('cssembed'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/DartFilter.php
+++ b/src/Assetic/Filter/DartFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Compiles Dart into Javascript.
@@ -36,13 +37,12 @@ class DartFilter extends BaseProcessFilter
 
         file_put_contents($input, $asset->getContent());
 
-        $pb = $this->createProcessBuilder()
-            ->add($this->dartBin)
-            ->add('-o'.$output)
-            ->add($input)
-        ;
+        $commandline =array(
+            $this->dartBin,
+            '-o'.$output,
+            $input);
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerApiFilter.php
@@ -40,6 +40,7 @@ class CompilerApiFilter extends BaseCompilerFilter
             'js_code'       => $asset->getContent(),
             'output_format' => 'json',
             'output_info'   => 'compiled_code',
+            'language'      => self::LANGUAGE_ECMASCRIPT3,
         );
 
         if (null !== $this->compilationLevel) {
@@ -89,10 +90,10 @@ class CompilerApiFilter extends BaseCompilerFilter
             }
             $context = stream_context_create($contextOptions);
 
-            $response = file_get_contents('http://closure-compiler.appspot.com/compile', false, $context);
+            $response = file_get_contents('https://closure-compiler.appspot.com/compile', false, $context);
             $data = json_decode($response);
         } elseif (defined('CURLOPT_POST') && !in_array('curl_init', explode(',', ini_get('disable_functions')))) {
-            $ch = curl_init('http://closure-compiler.appspot.com/compile');
+            $ch = curl_init('https://closure-compiler.appspot.com/compile');
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded'));
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
+++ b/src/Assetic/Filter/GoogleClosure/CompilerJarFilter.php
@@ -14,7 +14,7 @@ namespace Assetic\Filter\GoogleClosure;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * Filter for the Google Closure Compiler JAR.
@@ -44,69 +44,70 @@ class CompilerJarFilter extends BaseCompilerFilter
         $is64bit = PHP_INT_SIZE === 8;
         $cleanup = array();
 
-        $pb = new ProcessBuilder(array_merge(
+        $commandline = array_merge(
             array($this->javaPath),
             $is64bit
                 ? array('-server', '-XX:+TieredCompilation')
                 : array('-client', '-d32'),
             array('-jar', $this->jarPath)
-        ));
-
-        if (null !== $this->timeout) {
-            $pb->setTimeout($this->timeout);
-        }
+        );
 
         if (null !== $this->compilationLevel) {
-            $pb->add('--compilation_level')->add($this->compilationLevel);
+            array_push($commandline, '--compilation_level', $this->compilationLevel);
         }
 
         if (null !== $this->jsExterns) {
             $cleanup[] = $externs = FilesystemUtils::createTemporaryFile('google_closure');
             file_put_contents($externs, $this->jsExterns);
-            $pb->add('--externs')->add($externs);
+            array_push($commandline, '--externs', $externs);
         }
 
         if (null !== $this->externsUrl) {
             $cleanup[] = $externs = FilesystemUtils::createTemporaryFile('google_closure');
             file_put_contents($externs, file_get_contents($this->externsUrl));
-            $pb->add('--externs')->add($externs);
+            array_push($commandline, '--externs', $externs);
         }
 
         if (null !== $this->excludeDefaultExterns) {
-            $pb->add('--use_only_custom_externs');
+            array_push($commandline, '--use_only_custom_externs');
         }
 
         if (null !== $this->formatting) {
-            $pb->add('--formatting')->add($this->formatting);
+            array_push($commandline, '--formatting', $this->formatting);
         }
 
         if (null !== $this->useClosureLibrary) {
-            $pb->add('--manage_closure_dependencies');
+            array_push($commandline, '--manage_closure_dependencies');
         }
 
         if (null !== $this->warningLevel) {
-            $pb->add('--warning_level')->add($this->warningLevel);
+            array_push($commandline, '--warning_level', $this->warningLevel);
         }
 
         if (null !== $this->language) {
-            $pb->add('--language_in')->add($this->language);
+            array_push($commandline, '--language_in', $this->language);
         }
 
         if (null !== $this->flagFile) {
-            $pb->add('--flagfile')->add($this->flagFile);
+            array_push($commandline, '--flagfile', $this->flagFile);
         }
 
-        $pb->add('--js')->add($cleanup[] = $input = FilesystemUtils::createTemporaryFile('google_closure'));
+        array_push($commandline, '--js', $cleanup[] = $input = FilesystemUtils::createTemporaryFile('google_closure'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
-        $code = $proc->run();
+        $process = new Process($commandline);
+
+        if (null !== $this->timeout) {
+            $process->setTimeout($this->timeout);
+        }
+
+        $code = $process->run();
         array_map('unlink', $cleanup);
 
         if (0 !== $code) {
-            throw FilterException::fromProcess($proc)->setInput($asset->getContent());
+            throw FilterException::fromProcess($process)->setInput($asset->getContent());
         }
 
-        $asset->setContent($proc->getOutput());
+        $asset->setContent($process->getOutput());
     }
 }

--- a/src/Assetic/Filter/GssFilter.php
+++ b/src/Assetic/Filter/GssFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Filter for the Google Closure Stylesheets Compiler JAR.
@@ -84,48 +85,48 @@ class GssFilter extends BaseProcessFilter
     {
         $cleanup = array();
 
-        $pb = $this->createProcessBuilder(array(
+        $commandline =array(
             $this->javaPath,
             '-jar',
             $this->jarPath,
-        ));
+        );
 
         if (null !== $this->allowUnrecognizedFunctions) {
-            $pb->add('--allow-unrecognized-functions');
+            array_push($commandline, '--allow-unrecognized-functions');
         }
 
         if (null !== $this->allowedNonStandardFunctions) {
-            $pb->add('--allowed_non_standard_functions')->add($this->allowedNonStandardFunctions);
+            array_push($commandline, '--allowed_non_standard_functions', $this->allowedNonStandardFunctions);
         }
 
         if (null !== $this->copyrightNotice) {
-            $pb->add('--copyright-notice')->add($this->copyrightNotice);
+            array_push($commandline, '--copyright-notice', $this->copyrightNotice);
         }
 
         if (null !== $this->define) {
-            $pb->add('--define')->add($this->define);
+            array_push($commandline, '--define', $this->define);
         }
 
         if (null !== $this->gssFunctionMapProvider) {
-            $pb->add('--gss-function-map-provider')->add($this->gssFunctionMapProvider);
+            array_push($commandline, '--gss-function-map-provider', $this->gssFunctionMapProvider);
         }
 
         if (null !== $this->inputOrientation) {
-            $pb->add('--input-orientation')->add($this->inputOrientation);
+            array_push($commandline, '--input-orientation', $this->inputOrientation);
         }
 
         if (null !== $this->outputOrientation) {
-            $pb->add('--output-orientation')->add($this->outputOrientation);
+            array_push($commandline, '--output-orientation', $this->outputOrientation);
         }
 
         if (null !== $this->prettyPrint) {
-            $pb->add('--pretty-print');
+            array_push($commandline, '--pretty-print');
         }
 
-        $pb->add($cleanup[] = $input = FilesystemUtils::createTemporaryFile('gss'));
+        array_push($commandline, $cleanup[] = $input = FilesystemUtils::createTemporaryFile('gss'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         array_map('unlink', $cleanup);
 

--- a/src/Assetic/Filter/HandlebarsFilter.php
+++ b/src/Assetic/Filter/HandlebarsFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Compiles Handlebars templates into Javascript.
@@ -47,9 +48,9 @@ class HandlebarsFilter extends BaseNodeFilter
 
     public function filterLoad(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline = $this->nodeBin
             ? array($this->nodeBin, $this->handlebarsBin)
-            : array($this->handlebarsBin));
+            : array($this->handlebarsBin);
 
         if ($sourcePath = $asset->getSourcePath()) {
             $templateName = basename($sourcePath);
@@ -63,17 +64,17 @@ class HandlebarsFilter extends BaseNodeFilter
 
         file_put_contents($inputPath, $asset->getContent());
 
-        $pb->add($inputPath)->add('-f')->add($outputPath);
+        array_push($commandline, $inputPath,'-f',$outputPath);
 
         if ($this->minimize) {
-            $pb->add('--min');
+            array_push($commandline, '--min');
         }
 
         if ($this->simple) {
-            $pb->add('--simple');
+            array_push($commandline, '--simple');
         }
 
-        $process = $pb->getProcess();
+        $process = new Process($commandline);
         $returnCode = $process->run();
 
         unlink($inputPath);

--- a/src/Assetic/Filter/JpegoptimFilter.php
+++ b/src/Assetic/Filter/JpegoptimFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Runs assets through Jpegoptim.
@@ -53,20 +54,20 @@ class JpegoptimFilter extends BaseProcessFilter
 
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder(array($this->jpegoptimBin));
+        $commandline =array($this->jpegoptimBin);
 
         if ($this->stripAll) {
-            $pb->add('--strip-all');
+            array_push($commandline, '--strip-all');
         }
 
         if ($this->max) {
-            $pb->add('--max='.$this->max);
+            array_push($commandline, '--max='.$this->max);
         }
 
-        $pb->add($input = FilesystemUtils::createTemporaryFile('jpegoptim'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('jpegoptim'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $proc->run();
 
         if (false !== strpos($proc->getOutput(), 'ERROR')) {

--- a/src/Assetic/Filter/JpegtranFilter.php
+++ b/src/Assetic/Filter/JpegtranFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Runs assets through jpegtran.
@@ -69,28 +70,28 @@ class JpegtranFilter extends BaseProcessFilter
 
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder(array($this->jpegtranBin));
+        $commandline = array($this->jpegtranBin);
 
         if ($this->optimize) {
-            $pb->add('-optimize');
+            array_push($commandline,'-optimize');
         }
 
         if ($this->copy) {
-            $pb->add('-copy')->add($this->copy);
+            array_push($commandline,'-copy', $this->copy);
         }
 
         if ($this->progressive) {
-            $pb->add('-progressive');
+            array_push($commandline,'-progressive');
         }
 
         if (null !== $this->restart) {
-            $pb->add('-restart')->add($this->restart);
+            array_push($commandline,'-restart', $this->restart);
         }
 
-        $pb->add($input = FilesystemUtils::createTemporaryFile('jpegtran'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('jpegtran'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/LessFilter.php
+++ b/src/Assetic/Filter/LessFilter.php
@@ -16,6 +16,7 @@ use Assetic\Exception\FilterException;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\FilesystemUtils;
 use Assetic\Util\LessUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Loads LESS files.
@@ -137,15 +138,15 @@ EOF;
             $parserOptions['paths'][] = $loadPath;
         }
 
-        $pb = $this->createProcessBuilder();
+        $commandline = array();
 
-        $pb->add($this->nodeBin)->add($input = FilesystemUtils::createTemporaryFile('less'));
+        array_push($commandline, $this->nodeBin, $input = FilesystemUtils::createTemporaryFile('less'));
         file_put_contents($input, sprintf($format,
             json_encode($asset->getContent()),
             json_encode(array_merge($parserOptions, $this->treeOptions))
         ));
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/OptiPngFilter.php
+++ b/src/Assetic/Filter/OptiPngFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Runs assets through OptiPNG.
@@ -47,19 +48,19 @@ class OptiPngFilter extends BaseProcessFilter
 
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder(array($this->optipngBin));
+        $commandline =array($this->optipngBin);
 
         if (null !== $this->level) {
-            $pb->add('-o')->add($this->level);
+            array_push($commandline, '-o', $this->level);
         }
 
-        $pb->add('-out')->add($output = FilesystemUtils::createTemporaryFile('optipng_out'));
+        array_push($commandline, '-out', $output = FilesystemUtils::createTemporaryFile('optipng_out'));
         unlink($output);
 
-        $pb->add($input = FilesystemUtils::createTemporaryFile('optinpg_in'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('optinpg_in'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
 
         if (0 !== $code) {

--- a/src/Assetic/Filter/PngoutFilter.php
+++ b/src/Assetic/Filter/PngoutFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Runs assets through pngout.
@@ -87,32 +88,32 @@ class PngoutFilter extends BaseProcessFilter
 
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder(array($this->pngoutBin));
+        $commandline =array($this->pngoutBin);
 
         if (null !== $this->color) {
-            $pb->add('-c'.$this->color);
+            array_push($commandline, '-c'.$this->color);
         }
 
         if (null !== $this->filter) {
-            $pb->add('-f'.$this->filter);
+            array_push($commandline, '-f'.$this->filter);
         }
 
         if (null !== $this->strategy) {
-            $pb->add('-s'.$this->strategy);
+            array_push($commandline, '-s'.$this->strategy);
         }
 
         if (null !== $this->blockSplitThreshold) {
-            $pb->add('-b'.$this->blockSplitThreshold);
+            array_push($commandline, '-b'.$this->blockSplitThreshold);
         }
 
-        $pb->add($input = FilesystemUtils::createTemporaryFile('pngout_in'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('pngout_in'));
         file_put_contents($input, $asset->getContent());
 
         $output = FilesystemUtils::createTemporaryFile('pngout_out');
         unlink($output);
-        $pb->add($output .= '.png');
+        array_push($commandline, $output .= '.png');
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
 
         if (0 !== $code) {

--- a/src/Assetic/Filter/ReactJsxFilter.php
+++ b/src/Assetic/Filter/ReactJsxFilter.php
@@ -5,11 +5,12 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Compiles JSX (for use with React) into JavaScript.
  *
- * @link http://facebook.github.io/react/docs/jsx-in-depth.html
+ * @link   http://facebook.github.io/react/docs/jsx-in-depth.html
  * @author Douglas Greenshields <dgreenshields@gmail.com>
  */
 class ReactJsxFilter extends BaseNodeFilter
@@ -25,25 +26,24 @@ class ReactJsxFilter extends BaseNodeFilter
 
     public function filterLoad(AssetInterface $asset)
     {
-        $builder = $this->createProcessBuilder($this->nodeBin
+        $commandline = $this->nodeBin
             ? array($this->nodeBin, $this->jsxBin)
-            : array($this->jsxBin));
+            : array($this->jsxBin);
 
         $inputDir = FilesystemUtils::createThrowAwayDirectory('jsx_in');
-        $inputFile = $inputDir.DIRECTORY_SEPARATOR.'asset.js';
+        $inputFile = $inputDir . DIRECTORY_SEPARATOR . 'asset.js';
         $outputDir = FilesystemUtils::createThrowAwayDirectory('jsx_out');
-        $outputFile = $outputDir.DIRECTORY_SEPARATOR.'asset.js';
+        $outputFile = $outputDir . DIRECTORY_SEPARATOR . 'asset.js';
 
         // create the asset file
         file_put_contents($inputFile, $asset->getContent());
 
-        $builder
-            ->add($inputDir)
-            ->add($outputDir)
-            ->add('--no-cache-dir')
-        ;
+        array_push($commandline,
+            $inputDir,
+            $outputDir,
+            '--no-cache-dir');
 
-        $proc = $builder->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
 
         // remove the input directory and asset file

--- a/src/Assetic/Filter/RooleFilter.php
+++ b/src/Assetic/Filter/RooleFilter.php
@@ -15,6 +15,7 @@ use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Loads Roole files.
@@ -46,13 +47,13 @@ class RooleFilter extends BaseNodeFilter implements DependencyExtractorInterface
 
         file_put_contents($input, $asset->getContent());
 
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline =$this->nodeBin
             ? array($this->nodeBin, $this->rooleBin)
-            : array($this->rooleBin));
+            : array($this->rooleBin);
 
-        $pb->add($input);
+        array_push($commandline, $input);
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/Sass/SassFilter.php
+++ b/src/Assetic/Filter/Sass/SassFilter.php
@@ -111,65 +111,65 @@ class SassFilter extends BaseSassFilter
             $sassProcessArgs = array_merge(explode(' ', $this->rubyPath), $sassProcessArgs);
         }
 
-        $pb = $this->createProcessBuilder($sassProcessArgs);
+        $commandline =$sassProcessArgs);
 
         if ($dir = $asset->getSourceDirectory()) {
-            $pb->add('--load-path')->add($dir);
+            array_push($commandline, '--load-path', $dir);
         }
 
         if ($this->unixNewlines) {
-            $pb->add('--unix-newlines');
+            array_push($commandline, '--unix-newlines');
         }
 
         if (true === $this->scss || (null === $this->scss && 'scss' == pathinfo($asset->getSourcePath(), PATHINFO_EXTENSION))) {
-            $pb->add('--scss');
+            array_push($commandline, '--scss');
         }
 
         if ($this->style) {
-            $pb->add('--style')->add($this->style);
+            array_push($commandline, '--style', $this->style);
         }
 
         if ($this->precision) {
-            $pb->add('--precision')->add($this->precision);
+            array_push($commandline, '--precision', $this->precision);
         }
 
         if ($this->quiet) {
-            $pb->add('--quiet');
+            array_push($commandline, '--quiet');
         }
 
         if ($this->debugInfo) {
-            $pb->add('--debug-info');
+            array_push($commandline, '--debug-info');
         }
 
         if ($this->lineNumbers) {
-            $pb->add('--line-numbers');
+            array_push($commandline, '--line-numbers');
         }
 
         if ($this->sourceMap) {
-            $pb->add('--sourcemap');
+            array_push($commandline, '--sourcemap');
         }
 
         foreach ($this->loadPaths as $loadPath) {
-            $pb->add('--load-path')->add($loadPath);
+            array_push($commandline, '--load-path', $loadPath);
         }
 
         if ($this->cacheLocation) {
-            $pb->add('--cache-location')->add($this->cacheLocation);
+            array_push($commandline, '--cache-location', $this->cacheLocation);
         }
 
         if ($this->noCache) {
-            $pb->add('--no-cache');
+            array_push($commandline, '--no-cache');
         }
 
         if ($this->compass) {
-            $pb->add('--compass');
+            array_push($commandline, '--compass');
         }
 
         // input
-        $pb->add($input = FilesystemUtils::createTemporaryFile('sass'));
+        array_push($commandline, $input = FilesystemUtils::createTemporaryFile('sass'));
         file_put_contents($input, $asset->getContent());
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/SprocketsFilter.php
+++ b/src/Assetic/Filter/SprocketsFilter.php
@@ -15,14 +15,15 @@ use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Runs assets through Sprockets.
  *
  * Requires Sprockets 1.0.x.
  *
- * @link http://getsprockets.org/
- * @link http://github.com/sstephenson/sprockets/tree/1.0.x
+ * @link   http://getsprockets.org/
+ * @link   http://github.com/sstephenson/sprockets/tree/1.0.x
  *
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
@@ -79,11 +80,11 @@ EOF;
         $more = '';
 
         foreach ($this->includeDirs as $directory) {
-            $more .= 'options[:load_path] << '.var_export($directory, true)."\n";
+            $more .= 'options[:load_path] << ' . var_export($directory, true) . "\n";
         }
 
         if (null !== $this->assetRoot) {
-            $more .= 'options[:asset_root] = '.var_export($this->assetRoot, true)."\n";
+            $more .= 'options[:asset_root] = ' . var_export($this->assetRoot, true) . "\n";
         }
 
         if ($more) {
@@ -103,12 +104,12 @@ EOF;
             $more
         ));
 
-        $pb = $this->createProcessBuilder(array(
+        $commandline = array(
             $this->rubyBin,
             $input,
-        ));
+        );
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($tmpAsset);
         unlink($input);

--- a/src/Assetic/Filter/StylusFilter.php
+++ b/src/Assetic/Filter/StylusFilter.php
@@ -15,6 +15,7 @@ use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Loads STYL files.
@@ -91,16 +92,16 @@ EOF;
             $parserOptions['compress'] = $this->compress;
         }
 
-        $pb = $this->createProcessBuilder();
+        $commandline =array();
 
-        $pb->add($this->nodeBin)->add($input = FilesystemUtils::createTemporaryFile('stylus'));
+        array_push($commandline, $this->nodeBin, $input = FilesystemUtils::createTemporaryFile('stylus'));
         file_put_contents($input, sprintf($format,
             json_encode($asset->getContent()),
             json_encode($parserOptions),
             $this->useNib ? '.use(require(\'nib\')())' : ''
         ));
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/src/Assetic/Filter/TypeScriptFilter.php
+++ b/src/Assetic/Filter/TypeScriptFilter.php
@@ -14,11 +14,12 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * Compiles TypeScript into JavaScript.
  *
- * @link http://www.typescriptlang.org/
+ * @link   http://www.typescriptlang.org/
  * @author Jarrod Nettles <jarrod.nettles@icloud.com>
  */
 class TypeScriptFilter extends BaseNodeFilter
@@ -34,9 +35,9 @@ class TypeScriptFilter extends BaseNodeFilter
 
     public function filterLoad(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline = $this->nodeBin
             ? array($this->nodeBin, $this->tscBin)
-            : array($this->tscBin));
+            : array($this->tscBin);
 
         if ($sourcePath = $asset->getSourcePath()) {
             $templateName = basename($sourcePath);
@@ -45,14 +46,14 @@ class TypeScriptFilter extends BaseNodeFilter
         }
 
         $inputDirPath = FilesystemUtils::createThrowAwayDirectory('typescript_in');
-        $inputPath = $inputDirPath.DIRECTORY_SEPARATOR.$templateName.'.ts';
+        $inputPath = $inputDirPath . DIRECTORY_SEPARATOR . $templateName . '.ts';
         $outputPath = FilesystemUtils::createTemporaryFile('typescript_out');
 
         file_put_contents($inputPath, $asset->getContent());
 
-        $pb->add($inputPath)->add('--out')->add($outputPath);
+        array_push($commandline, $inputPath, '--out', $outputPath);
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($inputPath);
         rmdir($inputDirPath);

--- a/src/Assetic/Filter/UglifyCssFilter.php
+++ b/src/Assetic/Filter/UglifyCssFilter.php
@@ -14,6 +14,7 @@ namespace Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Util\FilesystemUtils;
+use Symfony\Component\Process\Process;
 
 /**
  * UglifyCss filter.
@@ -68,7 +69,7 @@ class UglifyCssFilter extends BaseNodeFilter
     }
 
     /**
-     * @see Assetic\Filter\FilterInterface::filterLoad()
+     * @see \Assetic\Filter\FilterInterface::filterLoad()
      */
     public function filterLoad(AssetInterface $asset)
     {
@@ -77,33 +78,33 @@ class UglifyCssFilter extends BaseNodeFilter
     /**
      * Run the asset through UglifyJs
      *
-     * @see Assetic\Filter\FilterInterface::filterDump()
+     * @see \Assetic\Filter\FilterInterface::filterDump()
      */
     public function filterDump(AssetInterface $asset)
     {
-        $pb = $this->createProcessBuilder($this->nodeBin
+        $commandline =$this->nodeBin
             ? array($this->nodeBin, $this->uglifycssBin)
-            : array($this->uglifycssBin));
+            : array($this->uglifycssBin);
 
         if ($this->expandVars) {
-            $pb->add('--expand-vars');
+            array_push($commandline, '--expand-vars');
         }
 
         if ($this->uglyComments) {
-            $pb->add('--ugly-comments');
+            array_push($commandline, '--ugly-comments');
         }
 
         if ($this->cuteComments) {
-            $pb->add('--cute-comments');
+            array_push($commandline, '--cute-comments');
         }
 
         // input and output files
         $input = FilesystemUtils::createTemporaryFile('uglifycss');
 
         file_put_contents($input, $asset->getContent());
-        $pb->add($input);
+        array_push($commandline, $input);
 
-        $proc = $pb->getProcess();
+        $proc = new Process($commandline);
         $code = $proc->run();
         unlink($input);
 

--- a/tests/Assetic/Test/Filter/AutoprefixerFilterTest.php
+++ b/tests/Assetic/Test/Filter/AutoprefixerFilterTest.php
@@ -45,7 +45,6 @@ CSS;
         //TODO in some point of future this test will fail. Update test when new versions come out?
         $expected = <<<CSS
 a {
-  display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
 }

--- a/tests/Assetic/Test/Filter/FilterTestCase.php
+++ b/tests/Assetic/Test/Filter/FilterTestCase.php
@@ -13,7 +13,7 @@ namespace Assetic\Test\Filter;
 
 use Assetic\Test\TestCase;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 abstract class FilterTestCase extends TestCase
 {
@@ -49,13 +49,15 @@ abstract class FilterTestCase extends TestCase
             $this->markTestSkipped('Unable to find `node` executable.');
         }
 
-        $pb = new ProcessBuilder(array($bin, '-e', 'require(\''.$module.'\')'));
+        $p = new Process(array($bin, '-e', 'require(\''.$module.'\')'), null);
 
         if (isset($_SERVER['NODE_PATH'])) {
-            $pb->setEnv('NODE_PATH', $_SERVER['NODE_PATH']);
+            $p->setEnv(array(
+                'NODE_PATH' => $_SERVER['NODE_PATH']
+            ));
         }
 
-        return 0 === $pb->getProcess()->run();
+        return 0 === $p->run();
     }
 
     private function ensurePaths($current, array $paths)

--- a/tests/Assetic/Test/Filter/UglifyJs2FilterTest.php
+++ b/tests/Assetic/Test/Filter/UglifyJs2FilterTest.php
@@ -13,7 +13,7 @@ namespace Assetic\Test\Filter;
 
 use Assetic\Asset\FileAsset;
 use Assetic\Filter\UglifyJs2Filter;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * @group integration
@@ -39,12 +39,15 @@ class UglifyJs2FilterTest extends FilterTestCase
         }
 
         // verify uglifyjs version
-        $pb = new ProcessBuilder($nodeBin ? array($nodeBin, $uglifyjsBin) : array($uglifyjsBin));
-        $pb->add('--version');
+        $commandline = $nodeBin ? array($nodeBin, $uglifyjsBin) : array($uglifyjsBin);
+        $commandline[] = '--version';
+
+        $process = new Process($commandline);
+
         if (isset($_SERVER['NODE_PATH'])) {
-            $pb->setEnv('NODE_PATH', $_SERVER['NODE_PATH']);
+            $process->setEnv(array('NODE_PATH' => $_SERVER['NODE_PATH']));
         }
-        if (0 !== $pb->getProcess()->run()) {
+        if (0 !== $process->run()) {
             $this->markTestSkipped('Incorrect version of UglifyJs');
         }
 
@@ -93,7 +96,7 @@ class UglifyJs2FilterTest extends FilterTestCase
         $this->filter->setCompress(true);
         $this->filter->filterDump($this->asset);
 
-        $this->assertContains('var foo', $this->asset->getContent());
+        $this->assertContains('console.log("hellow world")', $this->asset->getContent());
         $this->assertNotContains('var var1', $this->asset->getContent());
     }
 

--- a/tests/Assetic/Test/Filter/UglifyJsFilterTest.php
+++ b/tests/Assetic/Test/Filter/UglifyJsFilterTest.php
@@ -13,7 +13,7 @@ namespace Assetic\Test\Filter;
 
 use Assetic\Asset\FileAsset;
 use Assetic\Filter\UglifyJsFilter;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * @group integration
@@ -32,12 +32,17 @@ class UglifyJsFilterTest extends FilterTestCase
         }
 
         // verify uglifyjs version
-        $pb = new ProcessBuilder($nodeBin ? array($nodeBin, $uglifyjsBin) : array($uglifyjsBin));
-        $pb->add('--version');
+        $commandline = $nodeBin ? array($nodeBin, $uglifyjsBin) : array($uglifyjsBin);
+        array_push($commandline, '--version');
+
+        $process = new Process($commandline);
+
         if (isset($_SERVER['NODE_PATH'])) {
-            $pb->setEnv('NODE_PATH', $_SERVER['NODE_PATH']);
+            $process->setEnv(array(
+                'NODE_PATH' => $_SERVER['NODE_PATH']
+            ));
         }
-        if (0 === $pb->getProcess()->run()) {
+        if (0 === $process->run()) {
             $this->markTestSkipped('Incorrect version of UglifyJs');
         }
 


### PR DESCRIPTION
Updated all usages of ProcessBuilder to use Process as the builder class was removed in version 4.0.0 of symfony/process. Sadly this makes it incompatible with older versions.