### PR TITLE
Set postcss to use autoprefixer

### DIFF
--- a/src/Assetic/Filter/AutoprefixerFilter.php
+++ b/src/Assetic/Filter/AutoprefixerFilter.php
@@ -60,6 +60,9 @@ class AutoprefixerFilter extends BaseNodeFilter
         $pb = $this->createProcessBuilder(array($this->autoprefixerBin));
 
         $pb->setInput($input);
+        
+        $pb->add('--use')->add('autoprefixer');
+        
         if ($this->browsers) {
             $pb->add('-b')->add(implode(',', $this->browsers));
         }


### PR DESCRIPTION
I'm not sure what version of autoprefixer this filter was created for but according to the autoprefixer documentation it should run as a postcss plugin. The argument passed to the construct should be the path to the postcss executable and an argument needs to be set for it run with the autoprefixer plugin. I didn't update variable names to reflect the executable name change but I did add the argument needed for the command so that it works properly.